### PR TITLE
Refactor of codebase & elimination of partial codon warning

### DIFF
--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -24,9 +24,6 @@ from Bio.Data.CodonTable import ambiguous_generic_by_id
 from Bio.Align import MultipleSeqAlignment
 from Bio.Seq import Seq
 
-from Bio import BiopythonWarning
-import warnings
-
 # ------------------------------------------------------------------------------#
 # DEBUGGING HELP
 # import ipdb
@@ -107,19 +104,19 @@ class ExtractAndCollect:
                 self.plastid_data.main_odict_nucl[gene_name] = [seq_rec]
 
             # Step 2. Translate nucleotide sequence to amino acid sequence
-            seq_obj = feature.extract(rec).seq.translate(
+            prot_obj = seq_obj.translate(
                 table=11)  #, cds=True) # Getting error TTA is not stop codon.
 
             # Step 3. Save protein sequence to output dictionary
-            seq_rec = SeqRecord.SeqRecord(
-                seq_obj, id=seq_name, name="", description=""
+            prot_rec = SeqRecord.SeqRecord(
+                prot_obj, id=seq_name, name="", description=""
             )
             if gene_name in self.plastid_data.main_odict_prot.keys():
                 tmp = self.plastid_data.main_odict_prot[gene_name]
-                tmp.append(seq_rec)
+                tmp.append(prot_rec)
                 self.plastid_data.main_odict_prot[gene_name] = tmp
             else:
-                self.plastid_data.main_odict_prot[gene_name] = [seq_rec]
+                self.plastid_data.main_odict_prot[gene_name] = [prot_rec]
 
     def _extract_igs(self, rec: SeqRecord):
         """Extracts all IGS (intergenic spacers) from a given sequence record
@@ -765,16 +762,6 @@ class MainHelpers:
             log.critical(f"Unable to find alignment software `{softw}`")
             raise Exception()
 
-    @classmethod
-    def setup_warnings(cls):
-        def handle_biopython_warning(message, category, filename, lineno, file=None, line=None):
-            if "Partial codon, len(sequence) not a multiple of three" not in str(message):
-                # Let other warnings pass through
-                warnings.showwarning(message, category, filename, lineno, file, line)
-
-        # Register the warning handler function.
-        warnings.showwarning = handle_biopython_warning
-
     # constructor
     def __init__(self, args: argparse.Namespace):
         self._set_select_mode(args)
@@ -963,7 +950,6 @@ if __name__ == "__main__":
     par_args = parser.parse_args()
     log = MainHelpers.setup_logger(par_args)
     MainHelpers.test_if_alignsoftw_present()
-    MainHelpers.setup_warnings()
     main(par_args)
 # ------------------------------------------------------------------------------#
 # EOF

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -75,30 +75,26 @@ class ExtractAndCollect:
 
         def trim_mult_three(in_seq):
             trim_char = len(in_seq) % 3
-            if trim_char > 0:
+            if trim_char > 0 and seq_obj[:3] == "ATG":
                 in_seq = in_seq[:-trim_char]
+            elif trim_char > 0:
+                in_seq = None
             return in_seq
 
         features = [
             f for f in rec.features if f.type == "CDS" and "gene" in f.qualifiers
         ]
-
-        notMult3_warning_flag = any(
-            len(f.extract(rec).seq) % 3 != 0 for f in features
-        )
         for feature in features:
             gene_name = feature.qualifiers["gene"][0]
             seq_name = f"{gene_name}_{rec.name}"
 
             # Step 1. Extract nucleotide sequence of each gene
             seq_obj = feature.extract(rec).seq
+            seq_obj = trim_mult_three(seq_obj)
 
-            if notMult3_warning_flag or len(seq_obj) % 3 != 0:
-                if seq_obj[:3] == "ATG":  # If start codon 'ATG', trim sequence render multiple of 3.
-                    seq_obj = trim_mult_three(seq_obj)
-                else:
-                    log.warning(f"{gene_name} does not have a correct reading frame - skipping this gene")
-                    continue  # Skip to next gene of the fore loop.
+            if seq_obj is None:
+                log.warning(f"{seq_name} does not have a clear reading frame. Skipping this gene.")
+                continue # Skip to next gene of the for loop.
 
             seq_rec = SeqRecord.SeqRecord(
                 seq_obj, id=seq_name, name="", description=""
@@ -111,11 +107,6 @@ class ExtractAndCollect:
                 self.plastid_data.main_odict_nucl[gene_name] = [seq_rec]
 
             # Step 2. Translate nucleotide sequence to amino acid sequence
-
-            if notMult3_warning_flag and seq_obj is None:
-                log.warning(f"{seq_name} does not have a clear reading frame. Skipping this gene.")
-                continue  # Skip to next gene of the for loop.
-
             seq_obj = feature.extract(rec).seq.translate(
                 table=11)  #, cds=True) # Getting error TTA is not stop codon.
 


### PR DESCRIPTION
- `MainHelperFunctions` refactored from variable factory to `MainHelpers` with these variables as object instance variables
- Encapsulated the ordered dictionaries and related variables as `PlastidGenomeData`
- The logger `log` is in the scope of the script and not `global`
- The causes of the "Partial codon, len(sequence) not a multiple of three" Biopython warning was already being handled, so the use of `mult_err_flag` removed
- Addition of some class methods that execute common sequences of existing methods
- Minor refactoring of branching behavior