### PR TITLE
Addition of parallelization to multiple procedures & user-defined concatenation order

### DIFF
--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -324,7 +324,7 @@ class DataCleaning:
         log.info("  removing user-defined genes")
         if self.user_params.exclude_list:
             for excluded in self.user_params.exclude_list:
-                if excluded in self.plastid_data.nucleotides.items():
+                if excluded in self.plastid_data.nucleotides.keys():
                     del self.plastid_data.nucleotides[excluded]
                     if self.user_params.select_mode == "cds" and self.plastid_data.proteins:
                         del self.plastid_data.proteins[excluded]

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -994,14 +994,14 @@ def main(user_params: UserParameters):
     extractor = ExtractAndCollect(plastid_data, user_params)
     extractor.extract()
 
-    # cleaner = DataCleaning(plastid_data, user_params)
-    # cleaner.clean()
-    #
-    # aligncoord = AlignmentCoordination(plastid_data, user_params)
-    # aligncoord.save_unaligned()
-    # aligncoord.perform_MSA()
-    # aligncoord.collect_MSAs()
-    # aligncoord.concat_MSAs()
+    cleaner = DataCleaning(plastid_data, user_params)
+    cleaner.clean()
+
+    aligncoord = AlignmentCoordination(plastid_data, user_params)
+    aligncoord.save_unaligned()
+    aligncoord.perform_MSA()
+    aligncoord.collect_MSAs()
+    aligncoord.concat_MSAs()
 
     log.info("end of script\n")
     quit()

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -507,9 +507,9 @@ class AlignmentCoordination:
     def concat_MSAs(self):
         log.info("concatenate all successful alignments (in no particular order)")
 
-        # sort alphabetically if applicable
-        if self.user_params.order == "alpha":
-            self.success_list.sort(key=lambda t: t[0])
+        # sort alignments according to user specification
+        self.plastid_data.set_order_map()
+        self.success_list.sort(key=lambda t: self.plastid_data.order_map[t[0]])
 
         # Step 1. Define output names
         out_fn_nucl_concat_fasta = os.path.join(
@@ -778,8 +778,10 @@ class UserParameters:
 class PlastidData:
     def __init__(self, user_params: UserParameters):
         self._set_mode(user_params)
+        self._set_order_fun(user_params)
         self._set_nucleotides()
         self._set_proteins()
+        self.order_map = None
         self._set_files(user_params)
 
     def _set_mode(self, user_params: UserParameters):
@@ -796,6 +798,9 @@ class PlastidData:
             f for f in os.listdir(user_params.in_dir) if f.endswith(user_params.fileext)
         ]
 
+    def _set_order_fun(self, user_params: UserParameters):
+        self.order_fun = user_params.order
+
     @staticmethod
     def _add_plast_dict(pdict1: 'PlastidDict', pdict2: 'PlastidDict'):
         for key in pdict2.keys():
@@ -810,6 +815,14 @@ class PlastidData:
     def add_proteins(self, pdict: 'PlastidDict'):
         if self.proteins is not None:
             self._add_plast_dict(self.proteins, pdict)
+
+    def set_order_map(self):
+        order_list = list(self.nucleotides.keys())
+        if self.order_fun == "alpha":
+            order_list.sort()
+        self.order_map = {
+            nuc: index for index, nuc in enumerate(order_list)
+        }
 
 
 class PlastidDict:

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -12,7 +12,7 @@ import subprocess
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, as_completed
 from functools import partial
 from time import sleep
-from typing import Union, List, Callable, Tuple, Mapping
+from typing import Union, List, Callable, Tuple, Mapping, Optional
 from Bio import SeqIO, Nexus, SeqRecord, AlignIO
 from Bio.SeqFeature import FeatureLocation, CompoundLocation, ExactPosition, SeqFeature
 import coloredlogs
@@ -278,7 +278,7 @@ class DataCleaning:
         log.info("  removing duplicate annotations")
 
         ### Inner Function - Start ###
-        def remove_dups(my_dict: 'PlastidDict'):
+        def remove_dups(my_dict: dict):
             """my_dict is modified in place"""
             for k, v in my_dict.items():
                 unique_items = []
@@ -475,8 +475,8 @@ class AlignmentCoordination:
                 if len(success_list) > 0:
                     self.success_list.extend(success_list)
 
-    def _collect_MSA_list(self, nuc_list: List[str]):
-        def collect_MSA(k: str):
+    def _collect_MSA_list(self, nuc_list: List[str]) -> List[Tuple[str, MultipleSeqAlignment]]:
+        def collect_MSA(k: str) -> Optional[Tuple[str, MultipleSeqAlignment]]:
             # Step 1. Define input and output names
             aligned_nucl_fasta = os.path.join(self.user_params.out_dir, f"nucl_{k}.aligned.fasta")
             aligned_nucl_nexus = os.path.join(self.user_params.out_dir, f"nucl_{k}.aligned.nexus")
@@ -693,7 +693,7 @@ class BackTranslation:
         return aligned_nuc
 
     def _backtrans_seqs(self, protein_alignment: MultipleSeqAlignment, nucleotide_records: Mapping,
-                        key_function=lambda x: x):
+                        key_function: Callable[[str], str] = lambda x: x):
         """Thread nucleotide sequences onto a protein alignment."""
         aligned = []
         for protein in protein_alignment:

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -524,7 +524,7 @@ class AlignmentCoordination:
         return success_list
 
     def concat_MSAs(self):
-        log.info("concatenate all successful alignments (in no particular order)")
+        log.info(f"concatenate all successful alignments in `{self.user_params.order}` order")
 
         # sort alignments according to user specification
         self.plastid_data.set_order_map()

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -344,7 +344,6 @@ class AlignmentCoordination:
         self.plastid_data = plastid_data
         self.user_params = user_params
         self.success_list = None
-        log.info("conducting the alignment of extracted sequences")
 
     def save_unaligned(self):
         """Takes a dictionary of nucleotide sequences and saves all sequences of the same region
@@ -360,6 +359,7 @@ class AlignmentCoordination:
                 SeqIO.write(v, hndl, "fasta")
 
     def perform_MSA(self):
+        log.info("conducting the alignment of extracted sequences")
         if self.user_params.select_mode == "cds":
             self._prot_MSA()
         else:

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -49,6 +49,9 @@ class ExtractAndCollect:
         INPUT:  input folder, user specification on cds/int/igs
         OUTPUT: nucleotide and protein dictionaries
         """
+        log.info("parsing GenBank flatfiles and extracting their sequence annotations")
+        log.info(f"  using {self.user_params.num_threads} CPUs")
+
         # Step 1. Create the data for each worker
 
         # find the number of files each worker will handle

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -841,10 +841,7 @@ class PlastidData:
         }
 
 
-class PlastidDict:
-    def __init__(self):
-        self.odict = OrderedDict()
-
+class PlastidDict(OrderedDict):
     def _add_feature(self, feature: Union['GeneFeature', 'IntronFeature', 'ProteinFeature']):
         if feature.seq_obj is None:
             log.warning(f"{feature.seq_name} does not have a clear reading frame. Skipping this feature.")
@@ -853,10 +850,10 @@ class PlastidDict:
         record = SeqRecord.SeqRecord(
             feature.seq_obj, id=feature.seq_name, name="", description=""
         )
-        if feature.gene_name in self.odict.keys():
-            self.odict[feature.gene_name].append(record)
+        if feature.gene_name in self.keys():
+            self[feature.gene_name].append(record)
         else:
-            self.odict[feature.gene_name] = [record]
+            self[feature.gene_name] = [record]
 
     def _add_igs(self, igs: 'IntergenicFeature'):
         if igs.seq_obj is None:
@@ -867,38 +864,18 @@ class PlastidDict:
             igs.seq_obj, id=igs.seq_name, name="", description=""
         )
 
-        if igs.igs_name in self.odict.keys():
-            self.odict[igs.igs_name].append(record)
-        elif igs.inv_igs_name in self.odict.keys():
+        if igs.igs_name in self.keys():
+            self[igs.igs_name].append(record)
+        elif igs.inv_igs_name in self.keys():
             pass  # Don't count IGS in the IRs twice
         else:
-            self.odict[igs.igs_name] = [record]
-
-    def keys(self):
-        return self.odict.keys()
-
-    def size(self):
-        return len(self.odict)
-
-    def items(self):
-        return self.odict.items()
+            self[igs.igs_name] = [record]
 
     def add_feature(self, other: Union['GeneFeature', 'IntronFeature', 'ProteinFeature', 'IntergenicFeature']):
         if isinstance(other, IntergenicFeature):
             self._add_igs(other)
         else:
             self._add_feature(other)
-
-    # operator overloading
-    def __setitem__(self, key: str, value):
-        self.odict[key] = value
-
-    def __getitem__(self, item: str):
-        return self.odict[item]
-
-    def __delitem__(self, key):
-        del self.odict[key]
-
 
 # -----------------------------------------------------------------#
 

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -53,16 +53,7 @@ class ExtractAndCollect:
         log.info(f"  using {self.user_params.num_threads} CPUs")
 
         # Step 1. Create the data for each worker
-
-        # find the number of files each worker will handle
-        list_len = len(self.plastid_data.files) // self.user_params.num_threads
-
-        # create the first workers-1 lists
-        file_lists = []
-        for index in range(self.user_params.num_threads - 1):
-            file_lists.append(self.plastid_data.files[index * list_len: (index + 1) * list_len])
-        # create the final list, including the division remainder number of files
-        file_lists.append(self.plastid_data.files[(self.user_params.num_threads - 1) * list_len:])
+        file_lists = split_list(self.plastid_data.files, self.user_params.num_threads)
 
         # Step 2. Use ProcessPoolExecutor to parallelize extraction
         with ProcessPoolExecutor(max_workers=self.user_params.num_threads) as executor:
@@ -977,6 +968,19 @@ class IntergenicFeature:
 # ------------------------------------------------------------------------------#
 # MAIN
 # ------------------------------------------------------------------------------#
+def split_list(input_list: List, num_lists: int) -> List[List]:
+    # find the desired number elements in each list
+    list_len = len(input_list) // num_lists
+
+    # create the first num_lists-1 lists
+    nested_list = [
+        input_list[index * list_len: (index + 1) * list_len] for index in range(num_lists - 1)
+    ]
+    # create the final list, including the division remainder number of elements
+    nested_list.append(input_list[(num_lists - 1) * list_len:])
+    return nested_list
+
+
 def setup_logger(user_params: UserParameters) -> logging.Logger:
     logger = logging.getLogger(__name__)
     log_format = "%(asctime)s [%(levelname)s] %(message)s"

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -265,9 +265,9 @@ class DataCleaning:
         """
         self.plastid_data = plastid_data
         self.user_params = user_params
-        log.info("cleaning extracted sequence annotations")
 
     def clean(self):
+        log.info("cleaning extracted sequence annotations")
         self._dedup()
         self._remove_infreq()
         self._remove_short()

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -103,10 +103,13 @@ class ExtractAndCollect:
             extract_fun = None
 
         def extract_rec(file):
-            log.info(f"  parsing {file}")
-            filepath = os.path.join(self.user_params.in_dir, file)
-            record = SeqIO.read(filepath, "genbank")
-            extract_fun(record)
+            try:
+                log.info(f"  parsing {file}")
+                filepath = os.path.join(self.user_params.in_dir, file)
+                record = SeqIO.read(filepath, "genbank")
+                extract_fun(record)
+            except Exception as e:
+                log.error("%r generated an exception: %s" % (file, e))
 
         return extract_rec
 

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -472,12 +472,9 @@ class AlignmentCoordination:
                 for msa_list in nuc_lists
             ]
             for future in as_completed(future_to_success):
-                try:
-                    success_list = future.result()
-                    if len(success_list) > 0:
-                        self.success_list.extend(success_list)
-                except Exception as e:
-                    log.error(f"generated an exception: {e}")
+                success_list = future.result()
+                if len(success_list) > 0:
+                    self.success_list.extend(success_list)
 
     def _collect_MSA_list(self, nuc_list: List[str]):
         def collect_MSA(k: str):

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -7,6 +7,7 @@ __version__ = "m_gruenstaeudl@fhsu.edu|Wed 22 Nov 2023 04:35:09 PM CST"
 # IMPORTS
 import argparse
 import bisect
+import shutil
 import subprocess
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, as_completed
 from functools import partial
@@ -17,7 +18,6 @@ from Bio.SeqFeature import FeatureLocation, CompoundLocation, ExactPosition, Seq
 import coloredlogs
 from collections import OrderedDict
 from copy import deepcopy
-from distutils.spawn import find_executable
 from io import StringIO
 import logging
 import multiprocessing
@@ -1027,7 +1027,7 @@ def setup_logger(user_params: UserParameters) -> logging.Logger:
 
 
 def check_dependency(software: str = "mafft"):
-    if find_executable(software) is None:
+    if shutil.which(software) is None:
         log.critical(f"Unable to find alignment software `{software}`")
         raise Exception()
 

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -7,11 +7,11 @@ __version__ = "m_gruenstaeudl@fhsu.edu|Wed 22 Nov 2023 04:35:09 PM CST"
 # IMPORTS
 import argparse
 import bisect
+import subprocess
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, as_completed
 from functools import partial
 from typing import Union, List
 from Bio import SeqIO, Nexus, SeqRecord, AlignIO
-from Bio.Align import Applications  # line necessary; see: https://www.biostars.org/p/13099/
 from Bio.SeqFeature import FeatureLocation, CompoundLocation, ExactPosition, SeqFeature
 import coloredlogs
 from collections import OrderedDict
@@ -451,12 +451,10 @@ class AlignmentCoordination:
 
     def _mafft_align(self, input_file, output_file):
         """Perform sequence alignment using MAFFT"""
-        mafft_cline = Applications.MafftCommandline(
-            input=input_file, adjustdirection=True, thread=self.user_params.num_threads
-        )
-        stdout, stderr = mafft_cline()
-        with open(output_file, "w") as hndl:
-            hndl.write(stdout)
+        mafft_cmd = ["mafft", "--thread", str(self.user_params.num_threads), "--adjustdirection", input_file]
+        with open(output_file, 'w') as hndl, open(os.devnull, 'w') as devnull:
+            process = subprocess.Popen(mafft_cmd, stdout=hndl, stderr=devnull, text=True)
+            process.wait()
 
     def collect_MSAs(self):
         """Converts alignments to NEXUS format; then collect all successfully generated alignments

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -60,7 +60,7 @@ class ExtractAndCollect:
             self.plastid_data.add_proteins(prot_dict)
 
         # Step 1. Create the data for each worker
-        file_lists = split_list(self.plastid_data.files, self.user_params.num_threads)
+        file_lists = split_list(self.plastid_data.files, self.user_params.num_threads * 2)
 
         # Step 2. Use ProcessPoolExecutor to parallelize extraction
         with ProcessPoolExecutor(max_workers=self.user_params.num_threads) as executor:
@@ -463,7 +463,7 @@ class AlignmentCoordination:
         """
         log.info("collecting all successful alignments")
 
-        nuc_lists = split_list(list(self.plastid_data.nucleotides.keys()), self.user_params.num_threads)
+        nuc_lists = split_list(list(self.plastid_data.nucleotides.keys()), self.user_params.num_threads * 2)
         with ProcessPoolExecutor(max_workers=self.user_params.num_threads) as executor:
             future_to_success = [
                 executor.submit(self._collect_MSA_list, msa_list)


### PR DESCRIPTION
Changes that specifically address listed issues
- Extraction of GenBank files has been parallelized. Due to the nature of the operations done, multiprocessing was determined to be the best approach. This did require some refactoring, which can be noted in changes to the `PlastidData` class, the creation of the `PlastidDict` class, and the creation of helper methods related to the extraction of a sublist of files as well as individual files. From these new helpers, you will also see that multiprocessing occurs on sublists of the overall file list, as the overhead related to extracting each file in a separate process is less performant than single processing.
- The new user-provided argument `--order` is available, which relates to the concatenation order of the alignments. By default, the ordering is `seq` (sequence), corresponding to the sequence ordering of the features in the first input genome. With parallelization of extraction now occurring, for the `seq` option, the first file is extracted before the rest are parallelized to guarantee the specified order. The other option is `alpha` (alphabetic) which corresponds to the features being concatenated in alphabetic order.

Other changes
- The collection of successful alignments has also been parallelized by using multiprocessing. This choice was made for similar reasons as extraction and also uses sublists for the processes. As the collection of each nucleotide alignment does take much longer than the file extraction, the use of sublists is not as important, but there are minor gains compared to parallelizing the alignment collection individually.
- The use of the `mafft` wrapper provided by `Biopython` has been replaced by a `subprocess` call to `mafft`. There is no performance difference related to this update and was changed to prevent the depreciation of `Application` from causing issues in the future. The parallelization of `mafft` was investigated for improvements, but no obvious changes could be found. There may be changes to the parallelization of `mafft` and other processes that would decrease execution time, but that would probably involve targeting the software for a specific machine configuration.
- Both of the final concatenated alignment files are now written concurrently. This was mostly accomplished by taking advantage of the `export_fasta` method available to `alignm_concat` so that the Nexus file does not have to exist before the FASTA one.