### PR TITLE
Alpha version preparations

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -1,0 +1,122 @@
+# Workflow derived from https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+on:
+  push:
+    branches:
+      - master
+      - main
+    paths:
+      - 'pyproject.toml'
+
+name: build-and-publish
+
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Install pypa/build
+        run: >-
+          python3 -m
+          pip install
+          build
+          --user
+
+      - name: Build a binary wheel and a source tarball
+        run: python3 -m build
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/plastburstalign
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+
+  github-release:
+    name: >-
+      Sign the Python 🐍 distribution 📦 with Sigstore
+      and upload them to GitHub Release
+    needs:
+      - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v2.1.1
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
+
+      - name: Extract package name and version
+        run: |
+          # Extract the first .whl file name
+          FILE=$(ls dist/*.whl | head -n 1)
+          # Extract package name and version from the filename
+          PACKAGE_NAME=$(basename $FILE | sed -n 's/^\(.*\)-\([0-9]\+\(\.[0-9]\+\)*\)-.*/\1/p')
+          PACKAGE_VERSION=$(basename $FILE | sed -n 's/^\(.*\)-\([0-9]\+\(\.[0-9]\+\)*\)-.*/\2/p')
+          # Set output variables for GitHub Actions
+          echo "package_name=$PACKAGE_NAME" >> $GITHUB_ENV
+          echo "package_version=$PACKAGE_VERSION" >> $GITHUB_ENV
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create
+          '${{ env.package_name }}-${{ env.package_version }}'
+          --repo '${{ github.repository }}'
+          --notes ""
+
+      - name: Upload artifact signatures to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        # Upload to GitHub Release using the `gh` CLI.
+        # `dist/` contains the built packages, and the
+        # sigstore-produced signatures and certificates.
+        run: >-
+          gh release upload
+          '${{ env.package_name }}-${{ env.package_version }}' dist/**
+          --repo '${{ github.repository }}'

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -734,10 +734,12 @@ class BackTranslation:
         #    gap_codon = gap * 3
         ######
 
-
-        # Per https://biopython.org/docs/1.81/api/Bio.Seq.html this is proper replacement for depreciated method ungap.
-        #ungapped_protein = aligned_protein_record.seq.ungap(gap)
-        ungapped_protein = aligned_protein_record.seq.replace(self.gap, "")
+        # Per https://biopython.org/docs/1.81/api/Bio.Seq.html,
+        # `replace` is proper replacement for depreciated method `ungap`.
+        try:
+            ungapped_protein = aligned_protein_record.seq.replace(self.gap, "")
+        except AttributeError:
+            ungapped_protein = aligned_protein_record.seq.ungap(self.gap)
 
         ungapped_nucleotide = unaligned_nucleotide_record.seq
         if self.table:

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -16,7 +16,7 @@ from typing import Union, List, Callable, Tuple, Mapping, Optional
 from Bio import SeqIO, Nexus, SeqRecord, AlignIO
 from Bio.SeqFeature import FeatureLocation, CompoundLocation, ExactPosition, SeqFeature
 import coloredlogs
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from copy import deepcopy
 from io import StringIO
 import logging

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -1005,7 +1005,7 @@ class MAFFT:
             shutil.rmtree(self.dir)
 
     def _check_mafft(self):
-        if shutil.which("mafft") is not None:
+        if shutil.which("mafft") is None:
             log.info(f"using included MAFFT for alignment")
             script_dir = os.path.dirname(os.path.abspath(__file__))
             mafft_path = os.path.join(script_dir, "mafft")

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -1148,7 +1148,7 @@ class IntronFeature(PlastidFeature):
 
 class IntergenicFeature(PlastidFeature):
     type = "Intergenic spacer"
-    default_exception = "negative intergenic length (overlap)"
+    default_exception = "negative intergenic length"
 
     def __init__(self, record: SeqRecord, current_feat: SeqFeature, subsequent_feat: SeqFeature):
         self._set_sub_feat(subsequent_feat)
@@ -1163,16 +1163,8 @@ class IntergenicFeature(PlastidFeature):
         self.start_pos = ExactPosition(current_feat.location.end)  # +1)
         self.end_pos = ExactPosition(self.subsequent_feat.location.start)
         self.feature = FeatureLocation(self.start_pos, self.end_pos) if self.start_pos < self.end_pos else None
-
-    def _set_exception(self, exception: Exception = None):
-        super()._set_exception(exception)
-        log.debug(
-            f"\t{self.rec_name}: Exception occurred for IGS between "
-            f"`{self.nuc_name}` (start pos: {self.start_pos}) and "
-            f"`{self.subsequent_name}` (end pos:{self.end_pos}). "
-            f"Skipping this IGS ...\n"
-            f"Error message: {exception}"
-        )
+        self.default_exception = IntergenicFeature.default_exception + \
+                                 f" (start pos: {self.start_pos}, end pos:{self.end_pos})"
 
     def _set_seq_obj(self, record: SeqRecord):
         if self.feature is None:

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -1008,12 +1008,10 @@ class UserParameters:
         self.fileext = args.fileext
 
     def _set_exclude_list(self, args: argparse.Namespace):
-        exclude_list = args.excllist
-        if self.select_mode == "int":
-            self.exclude_list = [i + "_intron1" for i in exclude_list] + \
-                                [i + "_intron2" for i in exclude_list]
-        else:
-            self.exclude_list = exclude_list
+        self.exclude_list = args.excllist
+        if self.select_mode == "igs":
+            # Excluding matK is necessary, as matK is located inside trnK
+            self.exclude_list.append("matK")
 
     def _set_min_seq_length(self, args: argparse.Namespace):
         self.min_seq_length = args.minseqlength

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -639,10 +639,9 @@ class AlignmentCoordination:
                     "nexus",
                     molecule_type="DNA",
                 )
-            except Exception as e:
+            except Exception:
                 log.warning(
-                    f"Unable to convert alignment of `{k}` from FASTA to NEXUS.\n"
-                    f"Error message: {e}"
+                    f"Unable to convert alignment of `{k}` from FASTA to NEXUS."
                 )
                 return None
             # Step 3. Import NEXUS files and append to list for concatenation

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -322,6 +322,8 @@ class ExonSpliceInsertor:
         # list comprehension would create a new gene list
         for feature in self.compound_features:
             self.genes.remove(feature)
+        # reorder genes, even if we don't end up inserting anything
+        self.genes.sort(key=lambda gene: gene.location.end)
 
     def _create_simple(self):
         self.simple_features = []

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -1424,7 +1424,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--excllist",
         "-e",
-        type=list,
+        type=str,
+        nargs="+",
         required=False,
         default=["rps12"],
         help="(Optional) List of genes to be excluded",

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -201,6 +201,8 @@ class CompoundSplitting:
         log.info(f"   resolving cis-spliced genes in {self.record.name}")
         merger = ExonSpliceMerger(self.genes, self.record)
         merger.merge()
+        # reorder genes, even if we don't end up inserting anything
+        self.genes.sort(key=lambda gene: gene.location.end)
         log.info(f"   resolving trans-spliced genes in {self.record.name}")
         insertor = ExonSpliceInsertor(self.genes, self.record, merger.trans_list)
         insertor.insert()
@@ -320,8 +322,6 @@ class ExonSpliceInsertor:
         # list comprehension would create a new gene list
         for feature in self.compound_features:
             self.genes.remove(feature)
-        # reorder genes, even if we don't end up inserting anything
-        self.genes.sort(key=lambda gene: gene.location.end)
 
     def _create_simple(self):
         self.simple_features = []

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -1042,7 +1042,7 @@ class PlastidFeature:
 
     def __init__(self, record: SeqRecord, feature: SeqFeature):
         self._exception = None
-        self._seq_obj = None
+        self.seq_obj = None
 
         self._set_nuc_name(feature)
         self._set_rec_name(record)
@@ -1160,27 +1160,25 @@ class IntergenicFeature(PlastidFeature):
 
     def _set_feature(self, current_feat: SeqFeature):
         # Note: It's unclear if +1 is needed here.
-        start_pos = ExactPosition(current_feat.location.end)  # +1)
-        end_pos = ExactPosition(self.subsequent_feat.location.start)
-        self.feature = FeatureLocation(start_pos, end_pos) if start_pos < end_pos else None
+        self.start_pos = ExactPosition(current_feat.location.end)  # +1)
+        self.end_pos = ExactPosition(self.subsequent_feat.location.start)
+        self.feature = FeatureLocation(self.start_pos, self.end_pos) if self.start_pos < self.end_pos else None
 
     def _set_exception(self, exception: Exception = None):
         super()._set_exception(exception)
         log.debug(
             f"\t{self.rec_name}: Exception occurred for IGS between "
-            f"`{self.nuc_name}` (start pos: {self.feature.start}) and "
-            f"`{self.subsequent_name}` (end pos:{self.feature.end}). "
+            f"`{self.nuc_name}` (start pos: {self.start_pos}) and "
+            f"`{self.subsequent_name}` (end pos:{self.end_pos}). "
             f"Skipping this IGS ...\n"
             f"Error message: {exception}"
         )
 
     def _set_seq_obj(self, record: SeqRecord):
-        self.seq_obj = None
         if self.feature is None:
             self._set_exception()
-            return
-
-        super()._set_seq_obj(record)
+        else:
+            super()._set_seq_obj(record)
 
     def _set_seq_name(self):
         self.inv_nuc_name = f"{self.subsequent_name}_{self.nuc_name}"

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -1130,7 +1130,8 @@ class IntronFeature(PlastidFeature):
         super()._set_nuc_name(feature)
         self.nuc_name += "_intron" + str(self.offset + 1)
 
-    def _set_seq_obj(self, record: SeqRecord):
+    def _set_feature(self, feature: SeqFeature):
+        super()._set_feature(feature)
         exon_1 = self.feature.location.parts[self.offset]
         exon_2 = self.feature.location.parts[self.offset + 1]
         in_order = exon_2.start >= exon_1.end
@@ -1143,7 +1144,6 @@ class IntronFeature(PlastidFeature):
             self.feature.location = FeatureLocation(
                 exon_2.start, exon_1.end
             )
-        super()._set_seq_obj(record)
 
 
 class IntergenicFeature(PlastidFeature):

--- a/PlastomeRegionBurstAndAlign.py
+++ b/PlastomeRegionBurstAndAlign.py
@@ -256,11 +256,18 @@ class ExonSpliceMerger:
         self._current = current
         self._current_gene = PlastidFeature.get_safe_gene(current)
 
-    def _set_subsequent(self, subsequent: SeqFeature = None):
-        if subsequent is None:
-            self._subsequent_gene = "" if not self._current else self._current_gene
-            self._subsequent_loc = "" if not self._current else self._current.location
+    def _set_subsequent(self, subsequent_index: Optional[int] = None):
+        # if there is no subsequent feature
+        if subsequent_index == len(self.genes) or not self._current:
+            self._subsequent_gene: str = ""
+            self._subsequent_loc: Union[str, FeatureLocation] = ""
+        # typical behavior when proceeding to next iteration in `_resolve_cis`
+        elif subsequent_index is None:
+            self._subsequent_gene = self._current_gene
+            self._subsequent_loc = self._current.location
+        # typical behavior when performing non-complex exon merge in `_merge_adj_exons`
         else:
+            subsequent = self.genes[subsequent_index]
             self._subsequent_gene = PlastidFeature.get_safe_gene(subsequent)
             self._subsequent_loc = subsequent.location
 
@@ -277,7 +284,7 @@ class ExonSpliceMerger:
 
         # delete merged exon, and update new subsequent feature
         del self.genes[self._index + 1]
-        self._set_subsequent(self.genes[self._index + 1])
+        self._set_subsequent(self._index + 1)
 
     def _print_align(self):
         log.debug(

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# PlastomeBurstAndAlign
+# plastburstalign
 A Python tool to extract and align genes, introns, and intergenic spacers across hundreds of plastid genomes using associative arrays
 
-#### Installation on Linux (Debian)
-```
+### Installation on Linux (Debian)
+```bash
 # Alignment software
 apt install mafft
 
@@ -11,21 +11,52 @@ apt install python3-biopython
 apt install python3-coloredlogs
 ```
 
-#### Overview of process
-![](docs/PlastomeBurstAndAlign_ProcessOverview.png)
+### Overview of process
+![Depiction of plastomes being split according to specified feature type; these features and then aligned by region](docs/PlastomeBurstAndAlign_ProcessOverview.png)
 
-#### Main features
+### Main features
 - Extracts all genes, introns, or intergenic spacers from a set of plastid genomes in GenBank flatfile format, aligns the corresponding regions, and then saves the alignments
 - Saves both the marker-wise alignments and the concatenation of all alignments
 
-#### Additional features
+### Additional features
 - The sequence extraction and alignment of the genes/introns/intergenic spacers is parallelized and, thus, sped up by utilizing multiple CPUs.
 - The order of concatenation of the aligned genes/introns/intergenic spacers can be determined (via command-line argument `--order/-r`): either corresponding to the natural sequence order of the first input genome (option `seq`) or in alphabetic order (option `alpha`).
 - Even though GenBank flatfiles list trans-spliced genes (e.g., rps12) out of order (i.e., out of their natural order along the genome sequence), trans-spliced genes are repositioned and their exons automatically merged.
-- The sofwtare automatically adjusts for the majority of letter-case differences between gene annotations of different plastid genome records.
+- The software automatically adjusts for the majority of letter-case differences between gene annotations of different plastid genome records.
 
-#### Testing
+### Usage
+There are two main ways this package can be used, depending on one's use case.
+
+#### Package as a script
+With the package installed or with the current working directory at the same level as `plastburstalign` (relative path will not work) you can execute the package with something like
+```bash
+python -m plastburstalign
 ```
+which will execute the pipeline with default arguments.
+
+#### Package as a module
+You are also able to use the objects defined in the package to perform the pipeline within Python such as
+
+```python
+from plastburstalign import PlastomeRegionBurstAndAlign
+
+burst = PlastomeRegionBurstAndAlign()
+burst.execute()
+```
+which will perform the same action as the above command line use. That is, an execution of the pipeline with default arguments.
+
+You can also use individual components for your own use. For example, the `MAFFT` class can be used by itself like
+
+```python
+from plastburstalign import MAFFT
+
+mafft_1 = MAFFT()
+mafft_10 = MAFFT({"num_threads": 10})
+```
+which will instantiate a configuration of MAFFT that will execute with 1 thread and another that will execute with 10 threads.
+
+### Testing
+```bash
 cd benchmarking
 # CDS
 python test_script_cds.py benchmarking1
@@ -40,10 +71,10 @@ python test_script_igs.py benchmarking2
 - Dataset `benchmarking1.tar.gz`: all Asteraceae (n=155) listed in [Yang et al. 2022](https://www.frontiersin.org/journals/plant-science/articles/10.3389/fpls.2022.808156)
 - Dataset `benchmarking2.tar.gz`: all monocots (n=733) listed in [Yang et al. 2022](https://www.frontiersin.org/journals/plant-science/articles/10.3389/fpls.2022.808156)
 
-#### Exemplary usage
-See [this document](docs/exemplary_usage.md)
+### Exemplary usage
+See [this document](https://github.com/michaelgruenstaeudl/PlastomeBurstAndAlign/blob/main/docs/exemplary_usage.md)
 
 
-#### Generating more test data
-See [this document](docs/generating_test_data.md)
+### Generating more test data
+See [this document](https://github.com/michaelgruenstaeudl/PlastomeBurstAndAlign/blob/main/docs/generating_test_data.md)
 

--- a/benchmarking/test_script_cds.py
+++ b/benchmarking/test_script_cds.py
@@ -9,23 +9,22 @@ import time
 # Get the current directory of the test script
 script_dir = os.path.dirname(os.path.abspath(__file__))
 
-# Define the relative path to your Python script
-MYSCRIPT = "../PlastomeRegionBurstAndAlign.py"
+# Define the absolute path to the module
+mod_rel = ".."
+mod_path = os.path.join(script_dir, mod_rel)
 
 # Define the benchmarking dataset
 dataset = sys.argv[1]
 
-# Combine the directory of the test script with the relative path to the Python script
-full_script_path = os.path.join(script_dir, MYSCRIPT)
-
-# Define the path to the output directory
-folder_CDS = dataset+"/output_CDS"
+# Define the path to the input and output directory
+folder_data = os.path.join(script_dir, dataset)
+folder_CDS = os.path.join(folder_data, "output_CDS")
 
 # Step 1: Extract the tar.gz file
-subprocess.run(["tar", "-xf", dataset+".tar.gz"])
+subprocess.run(["tar", "-xf", os.path.join(script_dir, dataset+".tar.gz"), "-C", script_dir])
 
 # Step 2: Change the current directory to the selected dataset
-os.chdir(dataset)
+os.chdir(folder_data)
 subprocess.call('echo "Size of input dataset: $(ls *.gb 2>\\dev\\null | wc -l) GenBank files"', shell=True)
 subprocess.call('echo ""', shell=True)
 
@@ -36,9 +35,11 @@ subprocess.run(["mkdir", "-p", f"{folder_CDS}/02_aligned"])
 subprocess.run(["mkdir", "-p", f"{folder_CDS}/02_aligned/fasta"])
 subprocess.run(["mkdir", "-p", f"{folder_CDS}/02_aligned/nexus"])
 
-# Step 4: Run your Python script using the full_script_path
+# Step 4: Change the directory to the module and run it as a script
+os.chdir(mod_path)
 run_start = time.time()
-subprocess.run(["python3", full_script_path, "-i", ".", "-o", folder_CDS, "-s", "cds", "-t", "5", "-l", "6", "-n", "10"])
+subprocess.run(["python3", "-m", "plastburstalign",
+                "-i", folder_data, "-o", folder_CDS, "-s", "cds", "-t", "5", "-l", "6", "-n", "10"])
 run_end = time.time()
 
 # run this to remove the folder, if not can comment out

--- a/benchmarking/test_script_igs.py
+++ b/benchmarking/test_script_igs.py
@@ -9,23 +9,22 @@ import time
 # Get the current directory of the test script
 script_dir = os.path.dirname(os.path.abspath(__file__))
 
-# Define the relative path to your Python script
-MYSCRIPT = "../PlastomeRegionBurstAndAlign.py"
+# Define the absolute path to the module
+mod_rel = ".."
+mod_path = os.path.join(script_dir, mod_rel)
 
 # Define the benchmarking dataset
 dataset = sys.argv[1]
 
-# Combine the directory of the test script with the relative path to the Python script
-full_script_path = os.path.join(script_dir, MYSCRIPT)
-
-# Define the path to the output directory
-folder_IGS = dataset+"/output_IGS"
+# Define the path to the input and output directory
+folder_data = os.path.join(script_dir, dataset)
+folder_IGS = os.path.join(folder_data, "output_IGS")
 
 # Step 1: Extract the tar.gz file
-subprocess.run(["tar", "-xf", dataset+".tar.gz"])
+subprocess.run(["tar", "-xf", os.path.join(script_dir, dataset+".tar.gz"), "-C", script_dir])
 
 # Step 2: Change the current directory to the selected dataset
-os.chdir(dataset)
+os.chdir(folder_data)
 subprocess.call('echo "Size of input dataset: $(ls *.gb 2>\\dev\\null | wc -l) GenBank files"', shell=True)
 subprocess.call('echo ""', shell=True)
 
@@ -36,9 +35,11 @@ subprocess.run(["mkdir", "-p", f"{folder_IGS}/02_aligned"])
 subprocess.run(["mkdir", "-p", f"{folder_IGS}/02_aligned/fasta"])
 subprocess.run(["mkdir", "-p", f"{folder_IGS}/02_aligned/nexus"])
 
-# Step 4: Run your Python script using the full_script_path
+# Step 4: Change the directory to the module and run it as a script
+os.chdir(mod_path)
 run_start = time.time()
-subprocess.run(["python3", full_script_path, "-i", ".", "-o", folder_IGS, "-s", "igs", "-t", "5", "-l", "6", "-n", "10"])
+subprocess.run(["python3", "-m", "plastburstalign",
+                "-i", folder_data, "-o", folder_IGS, "-s", "igs", "-t", "5", "-l", "6", "-n", "10"])
 run_end = time.time()
 
 # run this to remove the folder, if not can comment out

--- a/benchmarking/test_script_int.py
+++ b/benchmarking/test_script_int.py
@@ -9,23 +9,22 @@ import time
 # Get the current directory of the test script
 script_dir = os.path.dirname(os.path.abspath(__file__))
 
-# Define the relative path to your Python script
-MYSCRIPT = "../PlastomeRegionBurstAndAlign.py"
+# Define the absolute path to the module
+mod_rel = ".."
+mod_path = os.path.join(script_dir, mod_rel)
 
 # Define the benchmarking dataset
 dataset = sys.argv[1]
 
-# Combine the directory of the test script with the relative path to the Python script
-full_script_path = os.path.join(script_dir, MYSCRIPT)
-
-# Define the path to the output directory
-folder_INT = dataset+"/output_INT"
+# Define the path to the input and output directory
+folder_data = os.path.join(script_dir, dataset)
+folder_INT = os.path.join(folder_data, "output_INT")
 
 # Step 1: Extract the tar.gz file
-subprocess.run(["tar", "-xf", dataset+".tar.gz"])
+subprocess.run(["tar", "-xf", os.path.join(script_dir, dataset+".tar.gz"), "-C", script_dir])
 
 # Step 2: Change the current directory to the selected dataset
-os.chdir(dataset)
+os.chdir(folder_data)
 subprocess.call('echo "Size of input dataset: $(ls *.gb 2>\\dev\\null | wc -l) GenBank files"', shell=True)
 subprocess.call('echo ""', shell=True)
 
@@ -36,9 +35,11 @@ subprocess.run(["mkdir", "-p", f"{folder_INT}/02_aligned"])
 subprocess.run(["mkdir", "-p", f"{folder_INT}/02_aligned/fasta"])
 subprocess.run(["mkdir", "-p", f"{folder_INT}/02_aligned/nexus"])
 
-# Step 4: Run your Python script using the full_script_path
+# Step 4: Change the directory to the module and run it as a script
+os.chdir(mod_path)
 run_start = time.time()
-subprocess.run(["python3", full_script_path, "-i", ".", "-o", folder_INT, "-s", "int", "-t", "5", "-l", "6", "-n", "10"])
+subprocess.run(["python3", "-m", "plastburstalign",
+                "-i", folder_data, "-o", folder_INT, "-s", "int", "-t", "5", "-l", "6", "-n", "10"])
 run_end = time.time()
 
 # run this to remove the folder, if not can comment out

--- a/docs/exemplary_usage.md
+++ b/docs/exemplary_usage.md
@@ -1,53 +1,56 @@
+### Exemplary usage
+
+#### Installing the package locally
+```bash
+cd ..
+python -m build
+pip install .
+```
+
 #### Unpacking benchmark dataset
-```
+```bash
+cd benchmarking
 tar xzf benchmarking1.tar.gz
-```
-
-#### Exemplary usage
-```
-# Adjust the following line if necessary
-MYSCRIPT=~/git/PlastomeBurstAndAlign/PlastomeRegionBurstAndAlign.py
-
-cd benchmarking1/
+cd benchmarking1
 ```
 
 ##### Extract and align coding regions
-```
+```bash
 folder_CDS=./output_CDS
 mkdir -p $folder_CDS
 mkdir -p $folder_CDS/01_unalign
 mkdir -p $folder_CDS/02_aligned
 mkdir -p $folder_CDS/02_aligned/fasta
 mkdir -p $folder_CDS/02_aligned/nexus
-python $MYSCRIPT -i . -o $folder_CDS -s cds 1>${folder_CDS}/${folder_CDS}.log 2>&1
+python -m plastburstalign -i . -o $folder_CDS -s cds 1>${folder_CDS}/${folder_CDS}.log 2>&1
 mv $folder_CDS/*.unalign.fasta $folder_CDS/01_unalign
 mv $folder_CDS/*.aligned.fasta $folder_CDS/02_aligned/fasta
 mv $folder_CDS/*.aligned.nexus $folder_CDS/02_aligned/nexus
 ```
 
 ##### Extract and align introns
-```
+```bash
 folder_INT=./output_INT
 mkdir -p $folder_INT
 mkdir -p $folder_INT/01_unalign
 mkdir -p $folder_INT/02_aligned
 mkdir -p $folder_INT/02_aligned/fasta
 mkdir -p $folder_INT/02_aligned/nexus
-python $MYSCRIPT -i . -o $folder_INT -s int 1>${folder_INT}/${folder_INT}.log 2>&1
+python -m plastburstalign -i . -o $folder_INT -s int 1>${folder_INT}/${folder_INT}.log 2>&1
 mv $folder_INT/*.unalign.fasta $folder_INT/01_unalign
 mv $folder_INT/*.aligned.fasta $folder_INT/02_aligned/fasta
 mv $folder_INT/*.aligned.nexus $folder_INT/02_aligned/nexus
 ```
 
 ##### Extract and align intergenic spacers
-```
+```bash
 folder_IGS=./output_IGS
 mkdir -p $folder_IGS
 mkdir -p $folder_IGS/01_unalign
 mkdir -p $folder_IGS/02_aligned
 mkdir -p $folder_IGS/02_aligned/fasta
 mkdir -p $folder_IGS/02_aligned/nexus
-python $MYSCRIPT -i . -o $folder_IGS -s igs 1>${folder_IGS}/${folder_IGS}.log 2>&1
+python -m plastburstalign -i . -o $folder_IGS -s igs 1>${folder_IGS}/${folder_IGS}.log 2>&1
 mv $folder_IGS/*.unalign.fasta $folder_IGS/01_unalign
 mv $folder_IGS/*.aligned.fasta $folder_IGS/02_aligned/fasta
 mv $folder_IGS/*.aligned.nexus $folder_IGS/02_aligned/nexus

--- a/docs/generating_test_data.md
+++ b/docs/generating_test_data.md
@@ -1,7 +1,7 @@
 #### How to generate test data
 
 ##### Setting up benchmark
-```
+```bash
 apt install ncbi-entrez-direct  # on Debian
 cd benchmarking1
 while read accn; do

--- a/plastburstalign/__init__.py
+++ b/plastburstalign/__init__.py
@@ -1,0 +1,13 @@
+__name__ = "plastburstalign"
+__author__ = "Michael Gruenstaeudl, PhD"
+__email__ = "m_gruenstaeudl@fhsu.edu"
+__version__ = "0.9.0"
+
+from .user_parameters import UserParameters
+from .plastid_data import PlastidData
+from .extract_and_collect import ExtractAndCollect, DataCleaning
+from .alignment_coordination import AlignmentCoordination, MAFFT
+from .plastome_burst_and_align import PlastomeRegionBurstAndAlign
+
+__all__ = ['PlastomeRegionBurstAndAlign', 'UserParameters', 'PlastidData',
+           'ExtractAndCollect', 'DataCleaning', 'AlignmentCoordination', 'MAFFT']

--- a/plastburstalign/__main__.py
+++ b/plastburstalign/__main__.py
@@ -1,0 +1,10 @@
+from .user_parameters import UserParametersScript
+from .plastome_burst_and_align import PlastomeRegionBurstAndAlign
+
+
+if __name__ == "__main__":
+    params = UserParametersScript()
+    burst_align = PlastomeRegionBurstAndAlign(params)
+    burst_align.execute()
+
+    print("\nend of script\n")

--- a/plastburstalign/alignment_coordination.py
+++ b/plastburstalign/alignment_coordination.py
@@ -1,0 +1,604 @@
+import glob
+import multiprocessing
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import zipfile
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, as_completed
+from io import StringIO
+from time import sleep
+from typing import List, Callable, Tuple, Mapping, Optional, Dict, Any
+
+import requests
+from Bio import SeqIO, Nexus, SeqRecord, AlignIO
+from Bio.Align import MultipleSeqAlignment
+from Bio.Data.CodonTable import ambiguous_generic_by_id
+from Bio.Seq import Seq
+
+# Package imports
+from .helpers import split_list
+from .logger import Logger, logger as log
+from .plastid_data import PlastidData
+
+
+class AlignmentCoordination:
+    def __init__(self, plastid_data: 'PlastidData', user_params: Dict[str, Any]):
+        """
+        Coordinates the alignment of nucleotide or protein sequences.
+
+        Args:
+            plastid_data: Plastid data to be aligned.
+            user_params: Specifications for how the alignment should be performed.
+                These are `num_threads`, `out_dir`, `verbose`, and `concat`.
+        """
+        self.plastid_data = plastid_data
+        self.user_params = user_params
+        self.success_list = []
+        self.mafft = MAFFT(user_params)
+        self._unaligned_saved = False
+        self._aligned_saved = False
+
+    def save_unaligned(self):
+        """
+        For each region in the plastid data, an unaligned nucleotide matrix of sequences is saved to file.
+        These are saved in FASTA format, located in the path specified by `user_params.out_dir`.
+        If the plastid data contains protein sequences, those are saved as unaligned protein matrices.
+        """
+        log.info("saving individual regions as unaligned nucleotide matrices")
+        for nuc in self.plastid_data.nucleotides.keys():
+            out_fn_unalign_nucl = os.path.join(self.user_params.get("out_dir"), f"nucl_{nuc}.unalign.fasta")
+            with open(out_fn_unalign_nucl, "w") as hndl:
+                SeqIO.write(self.plastid_data.nucleotides.get(nuc), hndl, "fasta")
+            # Write unaligned protein sequences to file
+            if self.plastid_data.mode.collects_proteins():
+                out_fn_unalign_prot = os.path.join(self.user_params.get("out_dir"), f"prot_{nuc}.unalign.fasta")
+                with open(out_fn_unalign_prot, "w") as hndl:
+                    SeqIO.write(self.plastid_data.proteins.get(nuc), hndl, "fasta")
+        self._unaligned_saved = True
+
+    def perform_MSA(self):
+        """
+        For each region in the plastid data, the sequences are aligned and saved to file as a nucleotide matrix.
+        These are saved in FASTA format, located in the path specified by `user_params.out_dir`.
+
+        In the nucleotide case, this is the direct process of aligning the unaligned matrix of each region
+        using a third-party software tool. For the protein case, each unaligned matrix is aligned, and
+        then back-translated to a nucleotide matrix before saving to file.
+        """
+        if not self.mafft.exec_path:
+            log.error("unable to align regions; alignment tool is not properly configured")
+            return
+        elif not self._unaligned_saved:
+            self.save_unaligned()
+
+        log.info("conducting the alignment of extracted sequences")
+        if self.plastid_data.mode.collects_proteins():
+            self._prot_MSA()
+        else:
+            self._nuc_MSA()
+        self._aligned_saved = True
+
+    def _nuc_MSA(self):
+        log.info(
+            f" conducting multiple sequence alignments based on nucleotide sequence data using "
+            f"{self.user_params.get('num_threads')} threads"
+        )
+
+        ### Inner Function - Start ###
+        def single_nuc_MSA(k: str):
+            log.debug(f" aligning {k}")
+            # Define input and output names
+            out_fn_unalign_nucl = os.path.join(self.user_params.get("out_dir"), f"nucl_{k}.unalign.fasta")
+            out_fn_aligned_nucl = os.path.join(self.user_params.get("out_dir"), f"nucl_{k}.aligned.fasta")
+            # Step 1. Align matrices via third-party alignment tool
+            self.mafft.align(out_fn_unalign_nucl, out_fn_aligned_nucl)
+        ### Inner Function - End ###
+
+        # Step 2. Use ThreadPoolExecutor to parallelize alignment and back-translation
+        if self.plastid_data.nucleotides.items():
+            with ThreadPoolExecutor(max_workers=self.user_params.get("num_threads")) as executor:
+                future_to_nucleotide = {
+                    executor.submit(single_nuc_MSA, k): k
+                    for k in self.plastid_data.nucleotides.keys()
+                }
+                for future in as_completed(future_to_nucleotide):
+                    k = future_to_nucleotide[future]
+                    try:
+                        future.result()  # If needed, you can handle results here
+                    except Exception as e:
+                        log.error("%r generated an exception: %s" % (k, e))
+        else:
+            log.critical("No items in nucleotide main dictionary to process")
+            raise Exception()
+
+    def _prot_MSA(self):
+        log.info(
+            f" conducting multiple sequence alignments based on protein sequence data, "
+            f"followed by back-translation to nucleotides using {self.user_params.get('num_threads')} threads"
+        )
+
+        ### Inner Function - Start ###
+        def single_prot_MSA(k: str):
+            log.debug(f" aligning {k}")
+            # Define input and output names
+            out_fn_unalign_prot = os.path.join(self.user_params.get("out_dir"), f"prot_{k}.unalign.fasta")
+            out_fn_aligned_prot = os.path.join(self.user_params.get("out_dir"), f"prot_{k}.aligned.fasta")
+            out_fn_unalign_nucl = os.path.join(self.user_params.get("out_dir"), f"nucl_{k}.unalign.fasta")
+            out_fn_aligned_nucl = os.path.join(self.user_params.get("out_dir"), f"nucl_{k}.aligned.fasta")
+            # Step 1. Align matrices based on their PROTEIN sequences via third-party alignment tool
+            self.mafft.align(out_fn_unalign_prot, out_fn_aligned_prot)
+            # Step 2. Conduct actual back-translation from PROTEINS TO NUCLEOTIDES
+            try:
+                translator = BackTranslation(
+                    out_fn_aligned_prot,
+                    out_fn_unalign_nucl,
+                    out_fn_aligned_nucl,
+                    11
+                )
+                translator.backtranslate()
+            except Exception as err:
+                log.warning(
+                    f"Unable to conduct back-translation of `{k}`. "
+                    f"Error message: {err}."
+                )
+        ### Inner Function - End ###
+
+        # Step 2. Use ThreadPoolExecutor to parallelize alignment and back-translation
+        with ThreadPoolExecutor(max_workers=self.user_params.get("num_threads")) as executor:
+            future_to_protein = {
+                executor.submit(single_prot_MSA, k): k
+                for k in self.plastid_data.nucleotides.keys()
+            }
+            for future in as_completed(future_to_protein):
+                k = future_to_protein[future]
+                try:
+                    future.result()  # If needed, you can handle results here
+                except Exception as e:
+                    log.error(f"{k} generated an exception: {e}")
+
+    def collect_MSAs(self):
+        """
+        For each region in the plastid data, the sequences are aligned and saved to file in NEXUS format
+        in the path specified by `user_params.out_dir`.
+        """
+        if not self._aligned_saved:
+            self.perform_MSA()
+
+        log.info(
+            f"collecting all successful alignments using {self.user_params.get('num_threads')} processes"
+        )
+        nuc_lists = split_list(list(self.plastid_data.nucleotides.keys()), self.user_params.get("num_threads") * 2)
+        mp_context = multiprocessing.get_context("fork")  # same method on all platforms
+        with ProcessPoolExecutor(max_workers=self.user_params.get("num_threads"), mp_context=mp_context) as executor:
+            future_to_success = [
+                executor.submit(self._collect_MSA_list, msa_list)
+                for msa_list in nuc_lists
+            ]
+            for future in as_completed(future_to_success):
+                success_list = future.result()
+                if len(success_list) > 0:
+                    self.success_list.extend(success_list)
+
+    def _collect_MSA_list(self, nuc_list: List[str]) -> List[Tuple[str, MultipleSeqAlignment]]:
+        def collect_MSA(k: str) -> Optional[Tuple[str, MultipleSeqAlignment]]:
+            log.debug(f"  attempting to convert {k} from FASTA to NEXUS")
+            # Step 1. Define input and output names
+            aligned_nucl_fasta = os.path.join(self.user_params.get("out_dir"), f"nucl_{k}.aligned.fasta")
+            aligned_nucl_nexus = os.path.join(self.user_params.get("out_dir"), f"nucl_{k}.aligned.nexus")
+            # Step 2. Convert FASTA alignment to NEXUS alignment
+            try:
+                AlignIO.convert(
+                    aligned_nucl_fasta,
+                    "fasta",
+                    aligned_nucl_nexus,
+                    "nexus",
+                    molecule_type="DNA",
+                )
+            except Exception:
+                log.warning(
+                    f"Unable to convert alignment of `{k}` from FASTA to NEXUS."
+                )
+                return None
+            # Step 3. Import NEXUS files and append to list for concatenation
+            try:
+                alignm_nexus = AlignIO.read(aligned_nucl_nexus, "nexus")
+                hndl = StringIO()
+                AlignIO.write(alignm_nexus, hndl, "nexus")
+                nexus_string = hndl.getvalue()
+                # The following line replaces the gene name of sequence name with 'concat_'
+                nexus_string = nexus_string.replace("\n" + k + "_", "\nconcat_")
+                alignm_nexus = Nexus.Nexus.Nexus(nexus_string)
+                return k, alignm_nexus  # Function 'Nexus.Nexus.combine' needs a tuple.
+            except Exception as e:
+                log.warning(
+                    f"Unable to add alignment of `{k}` to concatenation.\n"
+                    f"Error message: {e}"
+                )
+                return None
+
+        # new logger instance for this child process (multiprocessing assumed)
+        Logger.reinitialize_logger(self.user_params.get("verbose"))
+
+        # convert each alignment to NEXUS, write to file, and add to running list
+        success_list = []
+        for nuc in nuc_list:
+            alignm_tup = collect_MSA(nuc)
+            if alignm_tup is not None:
+                success_list.append(alignm_tup)
+        return success_list
+
+    def concat_MSAs(self):
+        """
+        Concatenated region alignments are saved to file in both NEXUS and FASTA formats,
+        located in the path specified by `user_params.out_dir`.
+        """
+        if not self.success_list:
+            self.collect_MSAs()
+
+        def concat_sync():
+            # Write concatenated alignments to file in NEXUS format
+            mp_context = multiprocessing.get_context("fork")
+            nexus_write = mp_context.Process(target=alignm_concat.write_nexus_data,
+                                             kwargs={"filename": out_fn_nucl_concat_nexus})
+            nexus_write.start()
+
+            # Write concatenated alignments to file in FASTA format
+            fasta_write = mp_context.Process(target=alignm_concat.export_fasta,
+                                             kwargs={"filename": out_fn_nucl_concat_fasta})
+            fasta_write.start()
+
+            # Wait for both files to be written before continuing
+            while nexus_write.is_alive() or fasta_write.is_alive():
+                sleep(0.5)
+
+        def concat_seq():
+            # Write concatenated alignments to file in NEXUS format
+            alignm_concat.write_nexus_data(filename=out_fn_nucl_concat_nexus)
+            log.info("  NEXUS written")
+
+            # Write concatenated alignments to file in FASTA format
+            AlignIO.convert(
+                out_fn_nucl_concat_nexus, "nexus", out_fn_nucl_concat_fasta, "fasta"
+            )
+            log.info("  FASTA written")
+
+        log.info(f" concatenating all successful alignments in `{self.plastid_data.order}` order")
+
+        # sort alignments according to user specification
+        self.plastid_data.set_order_map()
+        self.success_list.sort(key=lambda t: self.plastid_data.order_map[t[0]])
+
+        # Step 1. Define output names
+        out_fn_nucl_concat_fasta = os.path.join(
+            self.user_params.get("out_dir"), "nucl_" + str(len(self.success_list)) + "concat.aligned.fasta"
+        )
+        out_fn_nucl_concat_nexus = os.path.join(
+            self.user_params.get("out_dir"), "nucl_" + str(len(self.success_list)) + "concat.aligned.nexus"
+        )
+
+        # Step 2. Do concatenation
+        try:
+            alignm_concat = Nexus.Nexus.combine(
+                self.success_list
+            )  # Function 'Nexus.Nexus.combine' needs a tuple
+        except Exception as e:
+            log.critical("Unable to concatenate alignments.\n" f"Error message: {e}")
+            raise Exception()
+
+        # Step 3. Write concatenated alignment to file,
+        # either synchronously or sequentially, depending on user parameter
+        if self.user_params.get("concat"):
+            log.info(" writing concatenation to file sequentially")
+            concat_seq()
+        else:
+            log.info(" writing concatenation to file synchronously")
+            concat_sync()
+
+# -----------------------------------------------------------------#
+
+
+class BackTranslation:
+    def __init__(
+            self,
+            prot_align_file: str,
+            nuc_fasta_file: str,
+            nuc_align_file: str,
+            table: int = 0,
+            align_format: str = "fasta",
+            gap: str = "-"
+    ):
+        """
+        Coordinate the back-translation of protein sequences to nucleotide sequences.
+
+        Args:
+            prot_align_file: Path to the file containing the aligned protein sequences.
+            nuc_fasta_file: Path to the file containing the unaligned nucleotide sequences.
+            nuc_align_file: Path to the output file for the back-translated nucleotide sequences.
+            table: Genetic code table number (default is 0).
+            align_format: Format of the alignment file (default is 'fasta').
+            gap: String that designates a nucleotide gap (default is '-').
+        """
+        self.align_format = align_format
+        self.prot_align_file = prot_align_file
+        self.nuc_fasta_file = nuc_fasta_file
+        self.nuc_align_file = nuc_align_file
+        self.table = table
+        self.gap = gap
+
+    def _evaluate_nuc(self, identifier: str, nuc: Seq, prot: Seq) -> Seq:
+        """
+        Returns nucleotide sequence if works (can remove trailing stop).
+        """
+        if len(nuc) % 3:
+            log.debug(
+                f"Nucleotide sequence for {identifier} is length {len(nuc)} (not a multiple of three)"
+            )
+
+        p = str(prot).upper().replace("*", "X")
+        t = str(nuc.translate(self.table)).upper().replace("*", "X")
+        if len(t) == len(p) + 1:
+            if str(nuc)[-3:].upper() in ambiguous_generic_by_id[self.table].stop_codons:
+                # Allow this...
+                t = t[:-1]
+                nuc = nuc[:-3]  # edit return value
+        if len(t) != len(p):
+            debug = (
+                f"Inconsistent lengths for {identifier}, ungapped protein {len(p)}, "
+                f"tripled {len(p) * 3} vs ungapped nucleotide {len(nuc)}."
+            )
+            if t.endswith(p):
+                debug += f"\nThere are {len(t) - len(p)} extra nucleotides at the start."
+            elif t.startswith(p):
+                debug += f"\nThere are {len(t) - len(p)} extra nucleotides at the end."
+            elif p in t:
+                debug += "\nHowever, protein sequence found within translated nucleotides."
+            elif p[1:] in t:
+                debug += "\nHowever, ignoring first amino acid, protein sequence found within translated nucleotides."
+            log.debug(debug)
+
+        if t == p:
+            return nuc
+        elif p.startswith("M") and "M" + t[1:] == p:
+            if str(nuc[0:3]).upper() in ambiguous_generic_by_id[self.table].start_codons:
+                return nuc
+            else:
+                log.debug(
+                    f"Translation for {identifier} would match if {nuc[0:3].upper()} "
+                    f"was a start codon (check correct table used)"
+                )
+                log.warning(f"Translation check failed for {identifier}")
+
+        else:
+            m = "".join("." if x == y else "!" for (x, y) in zip(p, t))
+            if len(prot) < 70:
+                log.debug(
+                    f"Translation mismatch for {identifier} [0:{len(prot)}]\n"
+                    f"Protein:     {p}\n"
+                    f"             {m}\n"
+                    f"Translation: {t}\n"
+                )
+            else:
+                for offset in range(0, len(p), 60):
+                    log.debug(
+                        f"Translation mismatch for {identifier} [{offset}:{offset + 60}]\n"
+                        f"Protein:     {p[offset:offset + 60]}\n"
+                        f"             {m[offset:offset + 60]}\n"
+                        f"Translation: {t[offset:offset + 60]}\n"
+                    )
+            log.warning(f"Translation check failed for {identifier}")
+
+    def _backtrans_seq(self, aligned_protein_record: SeqRecord, unaligned_nucleotide_record: SeqRecord) -> SeqRecord:
+        # Per https://biopython.org/docs/1.81/api/Bio.Seq.html,
+        # `replace` is proper replacement for depreciated method `ungap`.
+        try:
+            ungapped_protein = aligned_protein_record.seq.replace(self.gap, "")
+        except AttributeError:
+            ungapped_protein = aligned_protein_record.seq.ungap(self.gap)
+
+        ungapped_nucleotide = unaligned_nucleotide_record.seq
+        if self.table:
+            ungapped_nucleotide = self._evaluate_nuc(
+                aligned_protein_record.id, ungapped_nucleotide, ungapped_protein
+            )
+        elif len(ungapped_protein) * 3 != len(ungapped_nucleotide):
+            log.debug(
+                f"Inconsistent lengths for {aligned_protein_record.id}, "
+                f"ungapped protein {len(ungapped_protein)}, "
+                f"tripled {len(ungapped_protein) * 3} vs "
+                f"ungapped nucleotide {len(ungapped_nucleotide)}"
+            )
+            log.warning(
+                f"Backtranslation failed for {aligned_protein_record.id} due to ungapped length mismatch"
+            )
+        if ungapped_nucleotide is None:
+            return None
+
+        seq = []
+        nuc = str(ungapped_nucleotide)
+        gap_codon = self.gap * 3
+        for amino_acid in aligned_protein_record.seq:
+            if amino_acid == self.gap:
+                seq.append(gap_codon)
+            else:
+                seq.append(nuc[:3])
+                nuc = nuc[3:]
+        if len(nuc) > 0:
+            log.debug(
+                f"Nucleotide sequence for {unaligned_nucleotide_record.id} "
+                f"longer than protein {aligned_protein_record.id}"
+            )
+            log.warning(
+                f"Backtranslation failed for {unaligned_nucleotide_record.id} due to unaligned length mismatch"
+            )
+            return None
+
+        aligned_nuc = unaligned_nucleotide_record[:]  # copy for most annotation
+        aligned_nuc.letter_annotation = {}  # clear this
+        aligned_nuc.seq = Seq("".join(seq))  # , alpha)  # Modification on 09-Sep-2022 by M. Gruenstaeudl
+        if len(aligned_protein_record.seq) * 3 != len(aligned_nuc):
+            log.debug(
+                f"Nucleotide sequence for {aligned_nuc.id} is length {len(aligned_nuc)} "
+                f"but protein sequence {aligned_protein_record.seq} is length {len(aligned_protein_record.seq)} "
+                f"(3 * {len(aligned_nuc)} != {len(aligned_protein_record.seq)})"
+            )
+            log.warning(
+                f"Backtranslation failed for {aligned_nuc.id} due to aligned length mismatch"
+            )
+            return None
+
+        return aligned_nuc
+
+    def _backtrans_seqs(self, protein_alignment: MultipleSeqAlignment, nucleotide_records: Mapping,
+                        key_function: Callable[[str], str] = lambda x: x):
+        """
+        Thread nucleotide sequences onto a protein alignment.
+        """
+        aligned = []
+        for protein in protein_alignment:
+            try:
+                nucleotide = nucleotide_records[key_function(protein.id)]
+            except KeyError:
+                raise ValueError(
+                    f"Could not find nucleotide sequence for protein {protein.id}"
+                )
+            sequence = self._backtrans_seq(protein, nucleotide)
+            if sequence is not None:
+                aligned.append(sequence)
+        return MultipleSeqAlignment(aligned)
+
+    def backtranslate(self):
+        """
+        Perform back-translation of a protein alignment to nucleotides.
+        """
+        # Step 1. Load the protein alignment
+        prot_align = AlignIO.read(self.prot_align_file, self.align_format)
+        # Step 2. Index the unaligned nucleotide sequences
+        nuc_dict = SeqIO.index(self.nuc_fasta_file, "fasta")
+        # Step 3. Perform back-translation
+        nuc_align = self._backtrans_seqs(prot_align, nuc_dict)
+        # Step 4. Write the back-translated nucleotide alignment to a file
+        with open(self.nuc_align_file, "w") as output_handle:
+            AlignIO.write(nuc_align, output_handle, self.align_format)
+
+
+class MAFFT:
+    def __init__(self, user_params: Optional[Dict[str, Any]] = None):
+        """
+        An interface for executing MAFFT alignment.
+
+        If the instance is able to detect an installed version of MAFFT, that will be used for alignment.
+        Alternatively, downloading a version to be used by the package will be attempted.
+        If this download is successful, this version will be used by the current instance of `MAFFT`
+        and will be immediately available for subsequent initializations.
+
+        Args:
+            user_params: Specifications for how the alignment should be performed.
+                This is `num_threads`.
+        """
+        log.info("configuring alignment tool")
+        self._set_num_threads(user_params)
+        self._set_platform()
+        self._set_exec_path()
+        self._check_mafft()
+        self._config_message()
+
+    def _set_num_threads(self, user_params: Optional[Dict[str, Any]]):
+        if user_params and isinstance(user_params, dict) and user_params.get("num_threads"):
+            self.num_threads = str(user_params.get("num_threads"))
+        else:
+            self.num_threads = "1"
+
+    def _set_platform(self):
+        platform = sys.platform
+        if platform.startswith("win"):
+            self.platform = "win"
+        elif platform == "darwin":
+            self.platform = "mac"
+        elif platform.startswith("linux"):
+            self.platform = "linux"
+        else:
+            self.platform = platform
+
+    def _set_exec_path(self):
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        mafft_scripts = glob.glob(os.path.join(script_dir, "mafft", f"*{self.platform}*", "mafft.bat"))
+        self.exec_path = mafft_scripts[0] if mafft_scripts else None
+
+    def _check_mafft(self):
+        if shutil.which("mafft"):
+            log.info(f"  using installed MAFFT for alignment")
+            self.exec_path = "mafft"
+        elif self.exec_path:
+            log.info(f"  using MAFFT provided by package")
+        else:
+            log.info(f"  unable to find MAFFT installed or included in package")
+            self._download_mafft()
+            self._extract_archive()
+
+    def _download_mafft(self):
+        self._archive_path = None
+        if self.platform == "win":
+            file_name = "mafft-7.526-win64-signed.zip"
+        elif self.platform == "mac":
+            file_name = "mafft-7.526-mac.zip?signed"
+        elif self.platform == "linux":
+            file_name = "mafft-7.526-linux.tgz"
+        else:
+            log.warning(f"  MAFFT does not provide a compiled version for this platform: {self.platform}")
+            return
+
+        url = f"https://mafft.cbrc.jp/alignment/software/{file_name}"
+        log.info("  attempting to download MAFFT")
+        response = requests.get(url)
+        if response.status_code == 200:
+            self._parent_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "mafft")
+            self._archive_path = os.path.join(self._parent_path, file_name)
+            if not os.path.exists(self._parent_path):
+                os.makedirs(self._parent_path)
+            with open(self._archive_path, 'wb') as file:
+                file.write(response.content)
+            log.info('  MAFFT downloaded successfully')
+        else:
+            log.error('  unable to download MAFFT')
+
+    def _extract_archive(self):
+        if not self._archive_path:
+            return
+
+        is_zip = not self.platform == "linux"
+        if is_zip:
+            with zipfile.ZipFile(self._archive_path, "r") as zip_hdl:
+                zip_hdl.extractall(self._parent_path)
+        else:
+            with tarfile.open(self._archive_path, "r") as tar_hdl:
+                tar_hdl.extractall(self._parent_path)
+        os.remove(self._archive_path)
+        self._set_exec_path()
+
+    def _config_message(self):
+        if self.exec_path:
+            log.info("  MAFFT was successfully configured")
+        else:
+            log.error("  MAFFT could not be successfully configured")
+
+    def align(self, input_file: str, output_file: str):
+        """
+        Performs sequence alignment using MAFFT.
+
+        Args:
+            input_file: Path of input sequence file.
+            output_file: Path of output sequence file.
+        """
+        if not self.exec_path:
+            log.error("  skipping attempted alignment; alignment tool is not properly configured")
+        elif not os.path.exists(input_file) or not isinstance(input_file, str):
+            log.error("  skipping attempted alignment; specified input file does not exist")
+        elif not isinstance(output_file, str):
+            log.error(f"  skipping attempted alignment; specified output file is incorrect type: {type(output_file)}")
+        else:
+            mafft_cmd = [self.exec_path, "--thread", self.num_threads, "--adjustdirection", input_file]
+            with open(output_file, 'w') as hndl, open(os.devnull, 'w') as devnull:
+                process = subprocess.Popen(mafft_cmd, stdout=hndl, stderr=devnull, text=True)
+                process.wait()

--- a/plastburstalign/extract_and_collect.py
+++ b/plastburstalign/extract_and_collect.py
@@ -1,0 +1,546 @@
+import bisect
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from functools import partial
+from typing import Union, List, Tuple, Optional, Any, Dict
+from Bio import SeqIO, SeqRecord
+from Bio.SeqFeature import FeatureLocation, CompoundLocation, SeqFeature
+from copy import deepcopy
+import multiprocessing
+import os
+
+# Package imports
+from .plastid_data import (PlastidData, PlastidDict, IntergenicDict,
+                           GeneFeature, ProteinFeature, IntergenicFeature,
+                           IntronFeature, PlastidFeature)
+from .logger import Logger, logger as log
+from .helpers import split_list
+
+
+class ExtractAndCollect:
+    def __init__(self, plastid_data: 'PlastidData', user_params: Dict[str, Any]):
+        """
+        Coordinates the parsing of GenBank flatfiles, the extraction of the contained sequence annotations,
+        and the collection of the resulting sequence records in a data structure.
+
+        Args:
+            plastid_data: Contains the locations of the files to be parsed,
+                and where the extracted records will be stored.
+            user_params: Specifications for how the extraction should be performed.
+                These are `num_threads`, `out_dir`, `verbose`, and `exclude_list`.
+        """
+        self.plastid_data = plastid_data
+        self.user_params = user_params
+        self._set_extract_fun()
+
+    def _set_extract_fun(self):
+        if self.plastid_data.mode == "cds":
+            self._extract_fun = self._extract_cds
+        elif self.plastid_data.mode == "igs":
+            self._extract_fun = self._extract_igs
+        elif self.plastid_data.mode == "int":
+            self._extract_fun = self._extract_int
+        else:
+            self._extract_fun = None
+
+    def extract(self):
+        """
+        Parses all GenBank flatfiles of a given folder and extracts
+        all sequence annotations of the type specified by the user for each flatfile.
+        """
+        log.info(
+            f"parsing GenBank flatfiles and extracting their sequence annotations using "
+            f"{self.user_params.get('num_threads')} processes"
+        )
+
+        # Step 0. Extract first genome in list for feature ordering
+        if self.plastid_data.order == "seq":
+            first_genome = self.plastid_data.files.pop(0)
+            nuc_dict, prot_dict = self._extract_recs([first_genome])
+            self.plastid_data.add_nucleotides(nuc_dict)
+            self.plastid_data.add_proteins(prot_dict)
+
+        # Step 1. Create the data for each worker
+        file_lists = split_list(self.plastid_data.files, self.user_params.get("num_threads") * 2)
+
+        # Step 2. Use ProcessPoolExecutor to parallelize extraction
+        mp_context = multiprocessing.get_context("fork")  # same method on all platforms
+        with ProcessPoolExecutor(max_workers=self.user_params.get("num_threads"), mp_context=mp_context) as executor:
+            future_to_nuc = [
+                executor.submit(self._extract_recs, file_list) for file_list in file_lists
+            ]
+            for future in as_completed(future_to_nuc):
+                nuc_dict, prot_dict = future.result()
+                self.plastid_data.add_nucleotides(nuc_dict)
+                self.plastid_data.add_proteins(prot_dict)
+
+        # Step 3. Stop execution if no nucleotides were extracted
+        if not self.plastid_data.nucleotides.items():
+            log.critical(f"No items in main dictionary: {self.user_params.get('out_dir')}")
+            raise Exception()
+
+    def _extract_recs(self, files: List[str]) -> Tuple['PlastidDict', 'PlastidDict']:
+        def extract_rec(file: str):
+            try:
+                log.info(f" parsing {os.path.basename(file)}")
+                record = SeqIO.read(file, "genbank")
+                extract_fun(record)
+            except Exception as e:
+                log.error(" %r generated an exception: %s" % (os.path.basename(file), e))
+
+        # new logger instance for this child process (multiprocessing assumed)
+        Logger.reinitialize_logger(self.user_params.get("verbose"))
+
+        # "bind" plastid dictionaries to the record extraction function
+        nuc_dict = IntergenicDict() if self.plastid_data.mode == 'igs' else PlastidDict()
+        extract_fun = partial(self._extract_fun, nuc_dict=nuc_dict)
+        if self.plastid_data.mode.collects_proteins():
+            prot_dict = PlastidDict()
+            extract_fun = partial(extract_fun, protein_dict=prot_dict)
+        else:
+            prot_dict = None
+
+        # extract the annotations and collect them in the plastid dictionaries
+        for f in files:
+            extract_rec(f)
+        return nuc_dict, prot_dict
+
+    def _extract_cds(self, rec: SeqRecord, nuc_dict: 'PlastidDict', protein_dict: 'PlastidDict'):
+        """
+        Extracts all CDS (coding sequences = genes) from a given sequence record
+        """
+        features = self._cds_features(rec)
+        for feature in features:
+            # Step 1. Extract nucleotide sequence of each gene and add to dictionary
+            gene = GeneFeature(rec, feature)
+            nuc_dict.add_feature(gene)
+
+            # Step 2. Translate nucleotide sequence to protein and add to dictionary
+            protein = ProteinFeature(gene=gene)
+            protein_dict.add_feature(protein)
+
+    def _extract_igs(self, rec: SeqRecord, nuc_dict: 'PlastidDict'):
+        """
+        Extracts all IGS (intergenic spacers) from a given sequence record
+        """
+        # Step 1. Extract all genes from record (i.e., cds, trna, rrna)
+        # Resulting list contains adjacent features in order of appearance on genome
+        all_genes = self._igs_features(rec)
+        # Step 2. Loop through genes
+        for count, idx in enumerate(range(0, len(all_genes) - 1), 1):
+            current_feat = all_genes[idx]
+            subsequent_feat = all_genes[idx + 1]
+
+            # Step 3. Make IGS SeqFeature
+            igs = IntergenicFeature(rec, current_feat, subsequent_feat)
+
+            # Step 4. Attach IGS to growing dictionary
+            nuc_dict.add_feature(igs)
+
+    def _extract_int(self, rec: SeqRecord, nuc_dict: 'PlastidDict'):
+        """
+        Extracts all INT (introns) from a given sequence record
+        """
+        features = self._int_features(rec)
+        for feature in features:
+            # Step 1.a. If one intron in gene:
+            if len(feature.location.parts) == 2:
+                intron = IntronFeature(rec, feature)
+                nuc_dict.add_feature(intron)
+
+            # Step 1.b. If two introns in gene:
+            elif len(feature.location.parts) == 3:
+                feature_copy = deepcopy(
+                    feature
+                )  # Important b/c feature is overwritten in extract_internal_intron()
+
+                intron = IntronFeature(rec, feature)
+                nuc_dict.add_feature(intron)
+
+                intron = IntronFeature(rec, feature_copy, 1)
+                nuc_dict.add_feature(intron)
+
+    def _cds_features(self, record: SeqRecord) -> List[SeqFeature]:
+        return [
+            f for f in record.features if f.type == "CDS" and self._not_exclude(f)
+        ]
+
+    def _igs_features(self, record: SeqRecord) -> List[SeqFeature]:
+        # Note: No need to include "if feature.type=='tRNA'", because all tRNAs are also annotated as genes
+        genes = [
+            f for f in record.features if f.type == "gene" and self._not_exclude(f)
+        ]
+        # Handle spliced exons
+        handler = ExonSpliceHandler(genes, record)
+        handler.resolve()
+        return genes
+
+    def _int_features(self, record: SeqRecord) -> List[SeqFeature]:
+        # Limiting the search to CDS containing introns
+        return [
+            f for f in record.features if (f.type == "CDS" or f.type == "tRNA") and self._not_exclude(f)
+        ]
+
+    def _not_exclude(self, feature: SeqFeature) -> bool:
+        gene = PlastidFeature.get_gene(feature)
+        return gene and gene not in self.user_params.get("exclude_list") and "orf" not in gene
+
+
+# -----------------------------------------------------------------#
+
+
+class ExonSpliceHandler:
+    def __init__(self, genes: List[SeqFeature], record: SeqRecord):
+        """
+        Coordinates the handling of spliced exons.
+        Cis and trans-spliced genes are considered separately.
+
+        Args:
+            genes: List of gene features.
+            record: Record that contains the genes.
+        """
+        self.genes = genes
+        self.record = record
+
+    def resolve(self):
+        """
+        The handling of compound locations begins with merging the locations of
+        cis-spliced genes. During this process, compound location genes qualified as "trans_splicing"
+        or containing rps12 are identified and removed from the genes list, as they will be handled next.
+
+        In the second step, the genes identified as trans-spliced are split into multiple simple location
+        features. Each of these splits results in a simple location feature for each contiguous location
+        of the compound location. All of these simple location features are inserted (or merged) into their
+        expected location in the gene list.
+        """
+        log.info(f"  resolving genes with compound locations in {self.record.name}")
+        log.info(f"   resolving cis-spliced genes in {self.record.name}")
+        merger = ExonSpliceMerger(self.genes, self.record)
+        merger.merge()
+        # reorder genes, even if we don't end up inserting anything
+        self.genes.sort(key=lambda gene: gene.location.end)
+        log.info(f"   resolving trans-spliced genes in {self.record.name}")
+        insertor = ExonSpliceInsertor(self.genes, self.record, merger.trans_list)
+        insertor.insert()
+
+
+class ExonSpliceMerger:
+    def __init__(self, genes: List[SeqFeature], record: SeqRecord):
+        """
+        Coordinates the handling of cis-spliced exons by merging.
+
+        Args:
+            genes: List of gene features.
+            record: Record that contains the genes.
+        """
+        self.genes = genes
+        self.rec_name: str = record.name
+
+    def merge(self):
+        """
+        Locations of compound cis-spliced genes are merged in-place as they occur within the source GenBank file
+        (no repositioning of the annotations). Adjacent genes of the same name are assumed to be separately annotated
+        cis-spliced genes and merged as well. During this process, compound location annotations qualified as
+        "trans_splicing" or containing the gene rps12 (these are known to be trans but are not always qualified as such)
+        are removed from the list of gene features, and retained in a separate list.
+        """
+        self._setup()
+        self._resolve_cis()
+
+    def _setup(self):
+        self._index = len(self.genes)
+        self.trans_list: List[SeqFeature] = []
+        self._current = None
+
+    def _resolve_cis(self):
+        for gene in reversed(self.genes):
+            self._update_genes(gene)
+
+            # we will not handle trans exons
+            if self._is_trans():
+                self._remove_trans()
+                continue
+
+            if type(gene.location) is CompoundLocation:
+                self._merge_cis_exons()
+                self._print_align()
+
+            if self._is_same_gene():
+                self._merge_adj_exons()
+                self._print_align()
+
+    def _is_trans(self):
+        return self._current.qualifiers.get("trans_splicing") or self._current_gene == "rps12"
+
+    def _is_same_gene(self):
+        return self._current_gene == self._subsequent_gene
+
+    def _remove_trans(self):
+        self.trans_list.append(self._current)
+        del self.genes[self._index]
+
+    def _update_genes(self, current: SeqFeature):
+        self._index -= 1
+        self._set_subsequent()
+        self._set_current(current)
+
+    def _set_current(self, current: SeqFeature):
+        self._current = current
+        self._current_gene = PlastidFeature.get_safe_gene(current)
+
+    def _set_subsequent(self, subsequent_index: Optional[int] = None):
+        # if there is no subsequent feature
+        if subsequent_index == len(self.genes) or not self._current:
+            self._subsequent_gene: str = ""
+            self._subsequent_loc: Union[str, FeatureLocation] = ""
+        # typical behavior when proceeding to next iteration in `_resolve_cis`
+        elif subsequent_index is None:
+            self._subsequent_gene = self._current_gene
+            self._subsequent_loc = self._current.location
+        # typical behavior when performing non-complex exon merge in `_merge_adj_exons`
+        else:
+            subsequent = self.genes[subsequent_index]
+            self._subsequent_gene = PlastidFeature.get_safe_gene(subsequent)
+            self._subsequent_loc = subsequent.location
+
+    def _merge_cis_exons(self):
+        loc_parts = self._current.location.parts
+        gene_start = min(p.start for p in loc_parts)
+        gene_end = max(p.end for p in loc_parts)
+        self._current.location = FeatureLocation(gene_start, gene_end)
+
+    def _merge_adj_exons(self):
+        gene_start = min(self._current.location.start, self._subsequent_loc.start)
+        gene_end = max(self._current.location.end, self._subsequent_loc.end)
+        self._current.location = FeatureLocation(gene_start, gene_end)
+
+        # delete merged exon, and update new subsequent feature
+        del self.genes[self._index + 1]
+        self._set_subsequent(self._index + 1)
+
+    def _print_align(self):
+        log.debug(
+            f"   Merging exons of {self._current_gene} within {self.rec_name}\n"
+            "-----------------------------------------------------------\n"
+            f"\t{self._current_gene}\t\t\t{self._subsequent_gene}\n"
+            f"\t{self._current.location}\t\t{self._subsequent_loc}\n"
+            "-----------------------------------------------------------\n"
+        )
+
+
+class ExonSpliceInsertor:
+    def __init__(self, genes: List[SeqFeature], record: SeqRecord,
+                 compound_features: Optional[List[SeqFeature]] = None):
+        """
+        Coordinates the handling of compound location features using insertion and merging.
+
+        Args:
+            genes: List of gene features.
+            record: Record that contains the genes.
+            compound_features: List of compound location features to be inserted, if already known (optional).
+        """
+        self.genes = genes
+        self.rec_name: str = record.name
+        self.compound_features = compound_features if compound_features is not None else None
+
+    def insert(self):
+        """
+        If `compound_features` is not provided, all compound location features are identified and
+        removed from the gene list. Otherwise, the provided `compound_feature` list is used,
+        and it is assumed that these correspond to the same record as `genes` and have already been removed
+        from this list.
+
+        The genes identified as having compound locations (detailed above) are then split into simple location
+        features. Each of these splits results in a simple location feature for each contiguous location
+        of the compound location.
+
+        We then examine each simple location and insert it into its expected location
+        in the gene list. The expected location is determined by comparing the simple feature's end location
+        with the end locations of the features in the gene list. If the expected location has no
+        overlap with the proceeding and succeeding genes, and the feature is a different gene from those two,
+        it is directly inserted into that expected location. Alternatively, if the expected location of the feature
+        results in a flanking gene (strictly adjacent or overlapping) to be the same as the gene to be
+        inserted they are merged. The merge can occur on the proceeding side. succeeding side, or both.
+        When merging the gene location, the start location is minimized and the end location is maximized.
+        """
+        if self.compound_features is None:
+            self._find_compounds()
+        if len(self.compound_features) == 0:
+            return
+        self._create_simple()
+        self._insert_simple()
+
+    def _find_compounds(self):
+        # find the compound features and remove them from the gene list
+        self.compound_features = [
+            f for f in self.genes if type(f.location) is CompoundLocation
+        ]
+        # directly remove elements from list;
+        # list comprehension would create a new gene list
+        for feature in self.compound_features:
+            self.genes.remove(feature)
+        # reorder genes, even if we don't end up inserting anything
+        self.genes.sort(key=lambda gene: gene.location.end)
+
+    def _create_simple(self):
+        self.simple_features = []
+        for f in self.compound_features:
+            self.simple_features.extend(
+                SeqFeature(location=p, type=f.type, id=f.id, qualifiers=f.qualifiers) for p in f.location.parts
+            )
+        self.simple_features.sort(key=lambda feat: feat.location.end, reverse=True)
+
+    def _insert_simple(self):
+        # find end locations of features for insertion index finding
+        self._end_positions = [
+            f.location.end for f in self.genes
+        ]
+
+        # insert the simple features at the correct indices in the gene list if applicable
+        for insert_feature in self.simple_features:
+            self._set_insert(insert_feature)
+            self._set_adj()
+            self._set_adj_tests()
+
+            # using adjacency checks, attempt to insert
+            self._try_repositioning()
+            self._try_merging()
+
+    def _set_insert(self, insert: SeqFeature):
+        self._insert = insert
+        self._is_repositioned = False
+        self._insert_gene = PlastidFeature.get_safe_gene(self._insert)
+
+        # extract feature location and find proper index
+        insert_location = self._insert.location
+        self._insert_start = insert_location.start
+        self._insert_end = insert_location.end
+        self._insert_index = bisect.bisect_left(self._end_positions, self._insert_end)
+
+    def _set_adj(self):
+        # set appropriate adjacent features
+        self._previous = None if self._insert_index == 0 else self.genes[self._insert_index - 1]
+        self._current = None if self._insert_index == len(self.genes) else self.genes[self._insert_index]
+
+        self._previous_gene = "\t" if not self._previous else PlastidFeature.get_safe_gene(self._previous)
+        self._current_gene = "" if not self._current else PlastidFeature.get_safe_gene(self._current)
+
+        self._previous_loc = "\t\t\t\t\t" if not self._previous else self._previous.location
+        self._current_loc = "" if not self._current else self._current.location
+
+    def _set_adj_tests(self):
+        # checks for how to handle the insert feature
+        self._is_same_previous = False if not self._previous else self._previous_gene == self._insert_gene
+        self._is_same_current = False if not self._current else self._current_gene == self._insert_gene
+
+        self._is_after_previous = not self._previous or self._previous_loc.end < self._insert_start
+        self._is_before_current = not self._current or self._insert_end < self._current_loc.start
+
+    def _try_repositioning(self):
+        # if insert feature does not overlap with adjacent features, and is a different gene from the others,
+        # directly insert
+        not_overlap = self._is_after_previous and self._is_before_current
+        not_same = not self._is_same_previous and not self._is_same_current
+        if not_overlap and not_same:
+            self._message = f"Repositioning {self._insert_gene} within {self.rec_name}"
+            self._insert_at_index()
+
+    def _try_merging(self):
+        if self._is_repositioned:
+            return
+
+        self._is_merged = False
+        self._merge_right()
+        self._merge_left()
+
+        # perform merge if needed
+        if self._is_merged:
+            self._insert = SeqFeature(
+                location=FeatureLocation(self._insert_start, self._insert_end, self._insert.location.strand),
+                type=self._insert.type, id=self._insert.id, qualifiers=self._insert.qualifiers
+            )
+            # new adjacent features
+            self._set_adj()
+            self._message = f"Merging exons of {self._insert_gene} within {self.rec_name}"
+            self._insert_at_index()
+
+    def _merge_right(self):
+        # if insert and current feature are the same gene, and insert starts before current,
+        # remove current feature, and update ending location
+        if self._is_same_current and self._insert_start < self._current_loc.start:
+            self._insert_end = self._current_loc.end
+            self._remove_at_index()
+            self._is_merged = True
+
+    def _merge_left(self):
+        # if insert and previous feature are the same gene,
+        # use the smaller start location, and remove previous feature
+        if self._is_same_previous:
+            self._insert_start = min(self._insert_start, self._previous_loc.start)
+            # elements in list will shift to left, so update index
+            self._insert_index -= 1
+            self._remove_at_index()
+            self._is_merged = True
+
+    def _insert_at_index(self):
+        self.genes.insert(self._insert_index, self._insert)
+        self._end_positions.insert(self._insert_index, self._insert_end)
+        self._print_align()
+        self._is_repositioned = True
+
+    def _remove_at_index(self):
+        del self.genes[self._insert_index]
+        del self._end_positions[self._insert_index]
+
+    def _print_align(self):
+        log.debug(
+            f"   {self._message}\n"
+            "-----------------------------------------------------------\n"
+            f"\t\t{self._previous_gene}\t\t\t\t{self._insert_gene}\t\t\t\t{self._current_gene}\n"
+            f"\t{self._previous_loc}\t{self._insert.location}\t{self._current_loc}\n"
+            "-----------------------------------------------------------\n"
+        )
+
+
+# -----------------------------------------------------------------#
+
+
+class DataCleaning:
+    def __init__(self, plastid_data: 'PlastidData', user_params: Dict[str, Any]):
+        """
+        Coordinates the cleaning (removal) of dictionary regions based on properties of the regions.
+
+        Args:
+            plastid_data: Plastid data to be cleaned.
+            user_params: Specifications for how the cleaning process should be performed.
+                These are `min_seq_length` and `min_num_taxa`.
+        """
+        self.plastid_data = plastid_data
+        self.user_params = user_params
+
+    def clean(self):
+        """
+        Cleans the nucleotide and protein dictionaries according to user specifications.
+        Specifically, this removes regions that are below the threshold of
+        `min_seq_length` or `min_num_taxa`.
+        """
+        log.info("cleaning extracted sequence annotations")
+        log.info(
+            f"  removing annotations that occur in fewer than {self.user_params.get('min_num_taxa')} taxa"
+        )
+        log.info(
+            f"  removing annotations whose longest sequence is shorter than {self.user_params.get('min_seq_length')} bp"
+        )
+        for k, v in list(self.plastid_data.nucleotides.items()):
+            self._remove_infreq(k, v)
+            self._remove_short(k, v)
+
+    def _remove_short(self, k, v):
+        longest_seq = max([len(s.seq) for s in v])
+        if longest_seq < self.user_params.get("min_seq_length"):
+            log.info(f"    removing {k} for not reaching the minimum sequence length defined")
+            self.plastid_data.remove_nuc(k)
+
+    def _remove_infreq(self, k, v):
+        if len(v) < self.user_params.get("min_num_taxa"):
+            log.info(f"    removing {k} for not reaching the minimum number of taxa defined")
+            self.plastid_data.remove_nuc(k)

--- a/plastburstalign/helpers.py
+++ b/plastburstalign/helpers.py
@@ -1,0 +1,30 @@
+from typing import List
+
+
+def split_list(input_list: List, num_lists: int) -> List[List]:
+    """
+    From a source list, creates a list of lists of the same elements of the original list,
+    where each inner list is the length of the specified number. If the length of the original
+    list is not evenly divided by the specified number, the last inner list will have a length
+    less than this number.
+
+    This provides a similar function as `itertools.batched()`, which
+    was added in Python 3.12.
+
+    Args:
+        input_list: List of objects.
+        num_lists: Number of lists to create.
+
+    Returns: List of lists.
+
+    """
+    # find the desired number elements in each list
+    list_len = len(input_list) // num_lists
+
+    # create the first num_lists-1 lists
+    nested_list = [
+        input_list[index * list_len: (index + 1) * list_len] for index in range(num_lists - 1)
+    ]
+    # create the final list, including the division remainder number of elements
+    nested_list.append(input_list[(num_lists - 1) * list_len:])
+    return nested_list

--- a/plastburstalign/logger.py
+++ b/plastburstalign/logger.py
@@ -1,0 +1,76 @@
+import logging
+import os
+
+import coloredlogs
+
+# Package imports
+from . import __email__, __version__
+
+
+class Logger:
+    """
+    A singleton class used to contain the `Logger` object used for all modules in the package.
+    """
+    _logger = None
+
+    def __new__(cls, verbose: bool = False):
+        """
+        Creates a new `Logger` object for the class if one does not already exist,
+        or if the current process is different from the process that originally created the `Logger`.
+        Otherwise, the existing `Logger` is used.
+
+        By default, the logging level is `logging.INFO`.
+
+        Args:
+            verbose: The level of logging: (False = `INFO`, True = `DEBUG`).
+        """
+        pid = os.getpid()
+        if cls._logger is None or cls._logger[0] != pid:
+            cls._logger = (pid, super().__new__(cls))
+            cls._logger[1]._setup_logger(verbose)
+        return cls._logger[1]
+
+    @classmethod
+    def _setup_logger(cls, verbose: bool = False):
+        cls.logger = logging.getLogger(__name__)
+        process_str = f" (process {cls._logger[0]}) " if verbose else " "
+        log_format = f"%(asctime)s{process_str}[%(levelname)s] %(message)s"
+        log_level = logging.DEBUG if verbose else logging.INFO
+        coloredlogs.install(fmt=log_format, level=log_level, logger=cls.logger)
+
+    @classmethod
+    def reinitialize_logger(cls, verbose: bool = False):
+        """
+        Reinitialize the logger for child processes in a multiprocessing context.
+
+        Args:
+            verbose: The level of logging: (False = `INFO`, True = `DEBUG`).
+        """
+        cls._logger = None
+        cls.__new__(cls, verbose)
+
+    @classmethod
+    def set_logger(cls, verbose: bool):
+        """
+        Mutator method for updating the `Logger` object.
+
+        Args:
+            verbose: The level of logging: (False = `INFO`, True = `DEBUG`).
+        """
+        cls._setup_logger(verbose)
+        cls.logger.debug(f"{__package__} {__email__}|{__version__}")
+
+    @classmethod
+    def get_logger(cls) -> logging.Logger:
+        """
+        Accessor method for retrieving the Logger object.
+
+        Returns:
+            The `Logger` object contained by the class.
+
+        """
+
+        return cls.logger
+
+
+logger = Logger().get_logger()

--- a/plastburstalign/plastid_data.py
+++ b/plastburstalign/plastid_data.py
@@ -1,0 +1,466 @@
+from typing import Optional, Dict, Any
+from Bio import SeqRecord
+from Bio.SeqFeature import FeatureLocation, ExactPosition, SeqFeature
+from collections import OrderedDict, defaultdict
+import os
+from re import sub, findall, match
+
+# Package imports
+from .logger import logger as log
+
+
+class PlastidData:
+    def __init__(self, user_params: Dict[str, Any]):
+        """
+        A data structure that primarily stores extracted sequence annotations.
+        Additionally, the source files to be extracted and the concatenation order of regions are stored.
+
+        Args:
+            user_params: Specifications for how the data structure should be created and maintained.
+                These are `select_mode`, `in_dir`, `fileext`, and `order`.
+        """
+        self._set_mode(user_params)
+        self._set_order_fun(user_params)
+        self._set_nucleotides()
+        self._set_proteins()
+        self.order_map = None
+        self._set_files(user_params)
+
+    def _set_mode(self, user_params: Dict[str, Any]):
+        self.mode = user_params.get("select_mode")
+
+    def _set_nucleotides(self):
+        self.nucleotides = IntergenicDict() if self.mode == "igs" else PlastidDict()
+
+    def _set_proteins(self):
+        self.proteins = PlastidDict() if self.mode.collects_proteins() else None
+
+    def _set_files(self, user_params: Dict[str, Any]):
+        self.files = [
+            os.path.join(user_params.get("in_dir"), f) for f in os.listdir(user_params.get("in_dir"))
+            if f.endswith(user_params.get("fileext"))
+        ]
+
+    def _set_order_fun(self, user_params: Dict[str, Any]):
+        self.order = user_params.get("order")
+
+    @staticmethod
+    def _add_plast_dict(pdict1: 'PlastidDict', pdict2: 'PlastidDict'):
+        for key in pdict2.keys():
+            if key in pdict1.keys():
+                pdict1[key].extend(pdict2[key])
+            else:
+                pdict1[key] = pdict2[key]
+
+    def _add_igs_dict(self, pdict: 'IntergenicDict'):
+        self.nucleotides.nuc_inv_map.update(pdict.nuc_inv_map)
+        for key in pdict.keys():
+            if key in self.nucleotides.keys():
+                self.nucleotides[key].extend(pdict[key])
+            # Don't count IGS in the IRs twice
+            elif self.nucleotides.nuc_inv_map.get(key) in self.nucleotides.keys():
+                continue
+            else:
+                self.nucleotides[key] = pdict[key]
+
+    def add_nucleotides(self, pdict: 'PlastidDict'):
+        """
+        Merges a dictionary of region annotations into the dictionary of nucleotide region annotations
+        maintained by the data structure.
+
+        Args:
+            pdict: Dictionary of nucleotide region annotations.
+        """
+        if isinstance(pdict, IntergenicDict):
+            self._add_igs_dict(pdict)
+        else:
+            self._add_plast_dict(self.nucleotides, pdict)
+        self.nucleotides.plastome_nucs.update(pdict.plastome_nucs)
+
+    def add_proteins(self, pdict: 'PlastidDict'):
+        """
+        Merges a dictionary of region annotations into the dictionary of protein region annotations
+        maintained by the data structure. If the extraction mode does not include proteins, calling
+        this method will do nothing.
+
+        Args:
+            pdict: Dictionary of protein region annotations.
+        """
+        if self.mode.collects_proteins():
+            self._add_plast_dict(self.proteins, pdict)
+            self.proteins.plastome_nucs.update(pdict.plastome_nucs)
+
+    def set_order_map(self):
+        """
+        Orders the keys of the nucleotide dictionary according to `order`, creates a map from region name to ordinal
+        ordering, and sets this map as `order_map`.
+        """
+        order_list = list(self.nucleotides.keys())
+        if self.order == "alpha":
+            order_list.sort()
+        self.order_map = {
+            nuc: index for index, nuc in enumerate(order_list)
+        }
+
+    def remove_nuc(self, nuc_name: str):
+        """
+        Removes the specified region from the nucleotide dictionary. If the extraction mode includes proteins,
+        this will also remove the region from the protein dictionary.
+
+        Args:
+            nuc_name: Name of the region to remove from the collected data.
+        """
+        if nuc_name not in self.nucleotides.keys():
+            return
+
+        del self.nucleotides[nuc_name]
+        if self.mode.collects_proteins():
+            del self.proteins[nuc_name]
+
+
+class PlastidDict(OrderedDict):
+    def __init__(self):
+        """
+        A dictionary used to store extracted sequence annotations.
+        """
+        super().__init__()
+        self.plastome_nucs = defaultdict(set)
+
+    def _not_id(self, nuc_name: str, rec_name: str) -> bool:
+        rec_set = self.plastome_nucs.get(rec_name)
+        return True if not rec_set else nuc_name not in rec_set
+
+    def _is_nuc(self, nuc_name: str) -> bool:
+        return nuc_name in self.keys()
+
+    def add_feature(self, feature: 'PlastidFeature'):
+        """
+        Adds an annotation to the dictionary. If an annotation with the same name has already been added
+        for the plastome (record name), it will not be added.
+
+        Args:
+            feature: A plastid feature annotation.
+        """
+        if feature.seq_obj is None:
+            log.warning(feature.status_str())
+            return
+
+        is_nuc = self._is_nuc(feature.nuc_name)
+        not_id = self._not_id(feature.nuc_name, feature.rec_name)
+        # if nuc list exists, and this nuc has not been added for the plastome
+        if is_nuc and not_id:
+            self[feature.nuc_name].append(feature.get_record())
+        # if the nuc list does not exist
+        elif not is_nuc:
+            self[feature.nuc_name] = [feature.get_record()]
+        # record that the feature for the plastome has been added
+        self.plastome_nucs[feature.rec_name].add(feature.nuc_name)
+
+
+class IntergenicDict(PlastidDict):
+    def __init__(self):
+        """
+        A dictionary used to store extracted intergenic regions.
+        """
+        super().__init__()
+        self.nuc_inv_map = {}
+
+    def add_feature(self, igs: 'IntergenicFeature'):
+        super().add_feature(igs)
+        self.nuc_inv_map[igs.nuc_name] = igs.inv_nuc_name
+
+
+# -----------------------------------------------------------------#
+
+
+class PlastidFeature:
+    _type: str = "Plastid feature"
+    _default_exception: str = "exception"
+
+    @staticmethod
+    def get_gene(feat: SeqFeature) -> Optional[str]:
+        """
+        Finds and returns the gene name for a feature. If the feature is not a gene, `None` will be returned.
+
+        Args:
+            feat: `Biopython` feature.
+
+        Returns:
+            The gene name.
+
+        """
+        return feat.qualifiers["gene"][0] if feat.qualifiers.get("gene") else None
+
+    @staticmethod
+    def clean_gene(gene: Optional[str], cut_trna: bool = True) -> Optional[str]:
+        """
+        Standardizes a gene name by case and delimiter usage. By default, it also removes additional
+        qualifiers in the name if tRNA. If there is no initial gene name (`None`), `None` will be returned.
+
+        Args:
+            gene: Gene name.
+            cut_trna: Option to disregard additional qualifiers from the name (default is `TRUE`).
+
+        Returns:
+            Cleaned gene name.
+
+        """
+        if not gene:
+            return None
+
+        # look for standardized gene name
+        gene_pattern = r"^[a-zA-Z]{3}[a-zA-Z0-9]+"
+        gene_sub = match(gene_pattern, gene)
+        # if non-standard, just return a "safe" version of the name
+        if not gene_sub:
+            return sub(
+                r"\W+", "_", gene.replace("-", "_")
+            )
+        # the first match is the beginning of the cleaned name
+        cleaned_gene = gene_sub.group()[0:3].lower() + gene_sub.group()[3].upper()
+        if cut_trna:
+            return cleaned_gene
+
+        # look for tRNA qualifiers
+        trna_pattern = r"(\b\w{3}\b)"
+        qual_subs = findall(trna_pattern, gene)
+        # if not tRNA, return the gene
+        if not qual_subs:
+            return cleaned_gene
+
+        # handle each tRNA qualifier appropriately
+        codon_pattern = r"\b[ACGTUacgtu]{3}\b"
+        for qualifier in qual_subs:
+            # insert delimiter
+            cleaned_gene += "_"
+            # qualifier is codon
+            if match(codon_pattern, qualifier):
+                cleaned_gene += qualifier.upper()
+            # qualifier is amino acid
+            else:
+                cleaned_gene += qualifier[0].upper() + qualifier[1:4].lower()
+        return cleaned_gene
+
+    @staticmethod
+    def get_safe_gene(feat: SeqFeature) -> Optional[str]:
+        """
+        Finds and returns the cleaned gene name for a feature. If the feature is not a gene, `None` will be returned.
+
+        Args:
+            feat: `Biopython` feature.
+
+        Returns:
+            Cleaned gene name.
+
+        """
+        return PlastidFeature.clean_gene(PlastidFeature.get_gene(feat))
+
+    def __init__(self, record: SeqRecord, feature: SeqFeature):
+        """
+        Primarily a wrapper for a `SeqRecord` that can be accessed by `get_record()`.
+        It contains other variables and methods that document the creation of the `SeqRecord`.
+
+        Args:
+            record: The record that the feature is being extracted from.
+            feature: The feature to be extracted.
+        """
+        self._exception = None
+        self.seq_obj = None
+
+        self._set_nuc_name(feature)
+        self._set_rec_name(record)
+        self._set_feature(feature)
+        self._set_seq_obj(record)
+        self._set_seq_name()
+
+    def _set_nuc_name(self, feature: SeqFeature):
+        self.nuc_name = self.get_safe_gene(feature)
+
+    def _set_rec_name(self, record: SeqRecord):
+        self.rec_name = record.name
+
+    def _set_feature(self, feature: SeqFeature):
+        self.feature = feature
+
+    def _set_seq_obj(self, record: SeqRecord):
+        try:
+            self.seq_obj = self.feature.extract(record).seq
+        except Exception as e:
+            self._set_exception(e)
+
+    def _set_seq_name(self):
+        self.seq_name = f"{self.nuc_name}_{self.rec_name}"
+
+    def _set_exception(self, exception: Exception = None):
+        if exception is None:
+            self._exception = self._default_exception
+        else:
+            self._exception = exception
+
+    def status_str(self) -> str:
+        """
+        Retrieves a string that describes the status of the contained `SeqRecord`.
+
+        Returns:
+            A string describing the `SeqRecord` status.
+
+        """
+        message = f"skipped due to {self._exception}" if self._exception else "successfully extracted"
+        return f"{self._type} '{self.nuc_name}' in {self.rec_name} {message}"
+
+    def get_record(self) -> SeqRecord:
+        """
+        Instantiates the contained `SeqRecord` and returns it.
+        If the `SeqRecord` could not be successfully extracted, `None` is returned.
+        Additional information about the `None` return can be accessed by `status_str()`.
+
+        Returns:
+            The instantiated `SeqRecord`.
+
+        """
+        if self.seq_obj:
+            return SeqRecord.SeqRecord(
+                self.seq_obj, id=self.seq_name, name="", description=""
+            )
+        return None
+
+
+class GeneFeature(PlastidFeature):
+    """
+    Primarily a wrapper for a gene `SeqRecord` that can be accessed by `get_record()`.
+    It contains other variables and methods that document the creation of the `SeqRecord`.
+    """
+
+    _type = "Gene"
+    _default_exception = "ambiguous reading frame"
+
+    def _set_seq_obj(self, record: SeqRecord):
+        super()._set_seq_obj(record)
+        self._trim_mult_three()
+
+    def _trim_mult_three(self):
+        """
+        Accesses if a proper reading frame exists for the gene.
+        """
+        trim_char = len(self.seq_obj) % 3
+        if trim_char > 0 and self.seq_obj[:3] == "ATG":
+            self.seq_obj = self.seq_obj[:-trim_char]
+        elif trim_char > 0:
+            self.seq_obj = None
+            self._set_exception()
+
+
+class ProteinFeature(GeneFeature):
+    _type = "Protein"
+    _default_exception = "ambiguous gene reading frame"
+
+    def __init__(self, record: SeqRecord = None, feature: SeqFeature = None, gene: GeneFeature = None):
+        """
+        Primarily a wrapper for a protein `SeqRecord` that can be accessed by `get_record()`.
+        It contains other variables and methods that document the creation of the `SeqRecord`.
+
+        If an existing gene feature (`gene`) is provided instead of a `Biopython` `record` and `feature`,
+        the object will be copied and the contained nucleotide sequence will be translated to a protein sequence.
+        This is how the class is used within the module, but the standard `PlastidFeature` constructor
+        exists for use cases where the nucleotide sequence of a feature is not used.
+
+        Args:
+            record: The record that the feature is being extracted from (default is `None`).
+            feature: The feature to be extracted (default is `None`).
+            gene: An existing gene feature (default is `None`).
+        """
+        # if we provide a GeneFeature to the constructor, we can just copy the attributes
+        if gene is not None:
+            self.__dict__.update(gene.__dict__)
+        else:
+            super().__init__(record, feature)
+        self._set_prot_obj()
+
+    def _set_prot_obj(self):
+        if self.seq_obj is None:
+            self._set_exception()
+            return
+
+        try:
+            self.seq_obj = self.seq_obj.translate(table=11)  # Getting error TTA is not stop codon.
+        except Exception as e:
+            self._set_exception(e)
+
+
+class IntronFeature(PlastidFeature):
+    _type = "Intron"
+
+    def __init__(self, record: SeqRecord, feature: SeqFeature, offset: int = 0):
+        """
+        Primarily a wrapper for an intron `SeqRecord` that can be accessed by `get_record()`.
+        It contains other variables and methods that document the creation of the `SeqRecord`.
+
+        Args:
+            record: The record that the feature is being extracted from.
+            feature: The feature to be extracted.
+            offset: An index offset for which intron is being considered (default is 0).
+        """
+        self.offset = offset
+        super().__init__(record, feature)
+
+    def _set_nuc_name(self, feature: SeqFeature):
+        super()._set_nuc_name(feature)
+        self.nuc_name += "_intron" + str(self.offset + 1)
+
+    def _set_feature(self, feature: SeqFeature):
+        super()._set_feature(feature)
+        exon_1 = self.feature.location.parts[self.offset]
+        exon_2 = self.feature.location.parts[self.offset + 1]
+        in_order = exon_2.start >= exon_1.end
+
+        if in_order:
+            self.feature.location = FeatureLocation(
+                exon_1.end, exon_2.start
+            )
+        else:
+            self.feature.location = FeatureLocation(
+                exon_2.start, exon_1.end
+            )
+
+
+class IntergenicFeature(PlastidFeature):
+    _type = "Intergenic spacer"
+    _default_exception = "negative intergenic length"
+
+    def __init__(self, record: SeqRecord, current_feat: SeqFeature, subsequent_feat: SeqFeature):
+        """
+        Primarily a wrapper for an intergenic spacer `SeqRecord` that can be accessed by `get_record()`.
+        It contains other variables and methods that document the creation of the `SeqRecord`.
+
+        Args:
+            record: The record that the feature is being extracted from.
+            current_feat: The feature that borders the beginning of the intergenic space.
+            subsequent_feat: The feature that borders the end of the intergenic space.
+        """
+        self._set_sub_feat(subsequent_feat)
+        super().__init__(record, current_feat)
+
+    def _set_sub_feat(self, subsequent_feat: SeqFeature):
+        self.subsequent_feat = subsequent_feat
+        self.subsequent_name = self.get_safe_gene(subsequent_feat)
+
+    def _set_feature(self, current_feat: SeqFeature):
+        # Note: It's unclear if +1 is needed here.
+        self.start_pos = ExactPosition(current_feat.location.end)  # +1)
+        self.end_pos = ExactPosition(self.subsequent_feat.location.start)
+        self.feature = FeatureLocation(self.start_pos, self.end_pos) if self.start_pos < self.end_pos else None
+        self.default_exception = (
+                f"{IntergenicFeature._default_exception}"
+                f" (start pos: {self.start_pos}, end pos:{self.end_pos})"
+        )
+
+    def _set_seq_obj(self, record: SeqRecord):
+        if self.feature is None:
+            self._set_exception()
+        else:
+            super()._set_seq_obj(record)
+
+    def _set_seq_name(self):
+        self.inv_nuc_name = f"{self.subsequent_name}_{self.nuc_name}"
+        self.nuc_name += "_" + self.subsequent_name
+        super()._set_seq_name()

--- a/plastburstalign/plastome_burst_and_align.py
+++ b/plastburstalign/plastome_burst_and_align.py
@@ -1,0 +1,38 @@
+from typing import Optional, Any, Dict
+
+# Package imports
+from .user_parameters import UserParameters
+from .plastid_data import PlastidData
+from .extract_and_collect import ExtractAndCollect, DataCleaning
+from .alignment_coordination import AlignmentCoordination
+
+
+class PlastomeRegionBurstAndAlign:
+    def __init__(self, user_params: Optional[Dict[str, Any]] = None):
+        """
+        Coordinates extraction of sequence annotations from GenBank flatfiles,
+        the alignment of those sequences grouped by region name,
+        and writing the concatenated MSA results to file in NEXUS and FASTA formats.
+
+        Args:
+            user_params: Specifications for how the execution should be performed.
+        """
+        if not user_params or not isinstance(user_params, dict):
+            self.user_params: Dict[str, Any] = UserParameters()
+        else:
+            self.user_params = user_params
+        self.plastid_data = PlastidData(self.user_params)
+
+    def execute(self):
+        """
+        Extracts all genes, introns, or intergenic spacers from a set of plastid genomes in GenBank flatfile format,
+        aligns the corresponding regions, and then saves the alignments.
+        """
+        extractor = ExtractAndCollect(self.plastid_data, self.user_params)
+        extractor.extract()
+
+        cleaner = DataCleaning(self.plastid_data, self.user_params)
+        cleaner.clean()
+
+        aligncoord = AlignmentCoordination(self.plastid_data, self.user_params)
+        aligncoord.concat_MSAs()

--- a/plastburstalign/user_parameters.py
+++ b/plastburstalign/user_parameters.py
@@ -1,0 +1,256 @@
+import argparse
+import multiprocessing
+import os
+from enum import auto, StrEnum
+from typing import List, Union, Any, Dict, Optional
+
+# Package imports
+from .logger import Logger, logger as log
+
+
+class SelectMode(StrEnum):
+    """
+    An enumeration class used to keep track of selection and alignment modes.
+    """
+    CDS = auto()
+    INT = auto()
+    IGS = auto()
+
+    def collects_proteins(self):
+        return self == type(self).CDS
+
+
+class UserParameters(Dict[str, Any]):
+    def __init__(
+            self,
+            in_dir: str = "./input",
+            out_dir: str = "./output",
+            select_mode: str = "cds",
+            fileext: str = ".gb",
+            exclude_list: Optional[List[str]] = None,
+            min_seq_length: int = 3,
+            min_num_taxa: int = 2,
+            num_threads: Union[str, int] = "auto",
+            verbose: bool = False,
+            order: str = "seq",
+            concat: bool = False
+    ):
+        """
+        A dictionary that validates user parameters that are to be used within the package.
+
+
+        Args:
+            in_dir: Path to input directory (which contains the GenBank files
+            out_dir: Path to output directory
+            select_mode: Type of regions to be extracted (i.e. `cds`, `int`, or `igs`)
+            fileext: File extension of input files
+            exclude_list: List of genes to be excluded
+            min_seq_length: Minimal sequence length (in bp) below which regions will not be extracted
+            min_num_taxa: Minimum number of taxa in which a region must be present to be extracted
+            num_threads: Number of CPUs to use; can be any positive integer or 'auto'
+            verbose: Enable verbose logging
+            order: Order that the alignments should be saved ('seq' or 'alpha')
+            concat: Enable sequential writing of concatenation files
+        """
+        super().__init__()
+        self._set_select_mode(select_mode)
+        self._set_in_dir(in_dir)
+        self._set_out_dir(out_dir)
+        self._set_fileext(fileext)
+        self._set_exclude_list(exclude_list)
+        self._set_min_seq_length(min_seq_length)
+        self._set_min_num_taxa(min_num_taxa)
+        self._set_num_threads(num_threads)
+        self._set_verbose(verbose)
+        self._set_order(order)
+        self._set_concat(concat)
+
+    def _set_select_mode(self, select_mode: str):
+        try:
+            self["select_mode"] = SelectMode(select_mode.lower())
+        except ValueError:
+            log.critical(f"Invalid selection mode provided: `{select_mode}`")
+            raise ValueError
+
+    def _set_in_dir(self, in_dir: str):
+        if not os.path.exists(in_dir) or not isinstance(in_dir, str):
+            log.critical(f"Input directory `{in_dir}` does not exist.")
+            raise FileNotFoundError
+        self["in_dir"] = in_dir
+
+    def _set_out_dir(self, out_dir: str):
+        if not os.path.exists(out_dir) or not isinstance(out_dir, str):
+            log.critical(f"Output directory `{out_dir}` does not exist.")
+            raise FileNotFoundError
+        self["out_dir"] = out_dir
+
+    def _set_fileext(self, fileext: str):
+        self._test_type("fileext", fileext, str)
+        self["fileext"] = fileext
+
+    def _set_exclude_list(self, exclude_list: Optional[List[str]]):
+        if not exclude_list:
+            exclude_list = ["rps12"]
+        self._test_type("exclude_list", exclude_list, list)
+        self["exclude_list"] = exclude_list
+        if self["select_mode"] == "igs":
+            # Excluding matK is necessary, as matK is located inside trnK
+            self["exclude_list"].append("matK")
+
+    def _set_min_seq_length(self, min_seq_length: int):
+        self._test_type("min_seq_length", min_seq_length, int)
+        self["min_seq_length"] = min_seq_length
+
+    def _set_min_num_taxa(self, min_num_taxa: int):
+        self._test_type("min_num_taxa", min_num_taxa, int)
+        self["min_num_taxa"] = min_num_taxa
+
+    def _set_num_threads(self, num_threads: Union[str, int]):
+        if isinstance(num_threads, str) and not num_threads.isnumeric():
+            try:
+                num_threads = os.cpu_count()
+            except NotImplementedError:
+                num_threads = multiprocessing.cpu_count()
+        elif isinstance(num_threads, str):
+            num_threads = int(num_threads)
+        self["num_threads"] = num_threads
+
+    def _set_verbose(self, verbose: bool):
+        self._test_type("verbose", verbose, bool)
+        self["verbose"] = verbose
+        Logger.set_logger(verbose)
+
+    def _set_order(self, order: str):
+        self._test_type("order", order, str)
+        if order == "alpha":
+            self["order"] = order
+        else:
+            self["order"] = "seq"
+
+    def _set_concat(self, concat: bool):
+        self._test_type("concat", concat, bool)
+        self["concat"] = concat
+
+    @staticmethod
+    def _test_type(param_name: str, param_val: Any, expected_type: Any):
+        if not isinstance(param_val, expected_type):
+            log.critical(f"Invalid `{param_name}` type provided: {type(param_val)}")
+            raise TypeError
+
+
+class UserParametersScript(UserParameters):
+    _construct_name_map: Dict[str, str] = {
+        "inpd": "in_dir",
+        "outd": "out_dir",
+        "selectmode": "select_mode",
+        "fileext": "fileext",
+        "excllist": "exclude_list",
+        "minseqlength": "min_seq_length",
+        "minnumtaxa": "min_num_taxa",
+        "numthreads": "num_threads",
+        "verbose": "verbose",
+        "order": "order",
+        "concat": "concat"
+    }
+
+    def __init__(self):
+        """
+        An interface to create `UserParameters` within the context of a script execution.
+        """
+        parser = self._get_parser()
+        args = parser.parse_args()
+        args_dict = self._get_construct_dict(args)
+        super().__init__(**args_dict)
+
+    @staticmethod
+    def _get_parser() -> argparse.ArgumentParser:
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "--inpd",
+            "-i",
+            type=str,
+            required=False,
+            help="path to input directory (which contains the GenBank files)",
+        )
+        parser.add_argument(
+            "--outd",
+            "-o",
+            type=str,
+            required=False,
+            help="(Optional) Path to output directory",
+        )
+        parser.add_argument(
+            "--selectmode",
+            "-s",
+            type=str,
+            required=False,
+            help="(Optional) Type of regions to be extracted (i.e. `cds`, `int`, or `igs`)",
+        )
+        parser.add_argument(
+            "--fileext",
+            "-f",
+            type=str,
+            required=False,
+            help="(Optional) File extension of input files",
+        )
+        parser.add_argument(
+            "--excllist",
+            "-e",
+            type=str,
+            nargs="+",
+            required=False,
+            help="(Optional) List of genes to be excluded",
+        )
+        parser.add_argument(
+            "--minseqlength",
+            "-l",
+            type=int,
+            required=False,
+            help="(Optional) Minimal sequence length (in bp) below which regions will not be extracted",
+        )
+        parser.add_argument(
+            "--minnumtaxa",
+            "-t",
+            type=int,
+            required=False,
+            help="(Optional) Minimum number of taxa in which a region must be present to be extracted",
+        )
+        parser.add_argument(
+            "--numthreads",
+            "-n",
+            type=int,
+            required=False,
+            help="(Optional) Number of CPUs to use; can be any positive integer or 'auto' (default)",
+        )
+        parser.add_argument(
+            "--verbose",
+            "-v",
+            action="store_true",
+            required=False,
+            help="(Optional) Enable verbose logging",
+        )
+        parser.add_argument(
+            "--order",
+            "-r",
+            type=str,
+            required=False,
+            help="(Optional) Order that the alignments should be saved ('seq' or 'alpha')",
+        )
+        parser.add_argument(
+            "--concat",
+            "-c",
+            action="store_true",
+            required=False,
+            help="(Optional) Enable sequential writing of concatenation files",
+        )
+        return parser
+
+    @classmethod
+    def _get_construct_dict(cls, args: argparse.Namespace) -> Dict[str, Any]:
+        # map the cmd argument names to class constructor parameters,
+        # and remove empty argument values (`None`)
+        args_dict = vars(args)
+        args_dict = {
+            cls._construct_name_map[k]: v for k, v in args_dict.items() if v
+        }
+        return args_dict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+
+[project]
+name = "plastburstalign"
+description = "A Python tool to extract and align genes, introns, and intergenic spacers across hundreds of plastid genomes using associative arrays"
+authors = [
+    {name = "Michael Gruenstaeudl, PhD", email = "m_gruenstaeudl@fhsu.edu"}
+]
+version = "0.9.0"
+
+requires-python = ">= 3.9"
+dependencies = [
+    "biopython>=1.78",
+    "coloredlogs>=14.0",
+]
+
+readme = "README.md"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+
+    "License :: OSI Approved :: BSD License",
+
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+]
+keywords = [
+    "bioinformatics",
+    "alignment",
+    "flatfile",
+    "MAFFT",
+]
+
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["plastburstalign"]
+
+
+[project.urls]
+Homepage = "https://gruenstaeudl-lab.com/"
+Repository = "https://github.com/michaelgruenstaeudl/PlastomeBurstAndAlign"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-python>=3.9
-biopython>=1.78
-coloredlogs>=14.0


### PR DESCRIPTION
Requested features

- The `DEBUG` log level corresponding to verbose logging has been implemented and the more detailed logging messages have been moved to this category.
- An additional compound location feature handler has been implemented, to address cis-spliced genes in place, without adjusting their position in the features list. Note that this will also merge cis-spliced genes that are annotated separately. Now when the `split()` method of `CompoundSplitting` is called, first the cis-spliced genes will be merged, and then the trans-spliced features found during this process (which includes all occurrences of rps12, as not all are annotated as trans) are then split and inserted into their location in the plastome sequence.
- The class wrappers for `SeqFeature`s have been refactored into a class hierarchy. Among other things, this simplifies the process of retrieving a string representation of the state of the `SeqRecord`. When the `SeqRecord` can not be created, this string includes a description of why it was not extracted.
- A more robust gene name standardization process has been implemented. This attempts to standardize the case of the name, and when appropriate, performs a similar process to tRNA name qualifiers. Due to the inconsistent use of tRNA anticodon and amino acid qualifiers in the benchmark data, the function includes an option to exclude these in the returned gene name. By default, the qualifiers are excluded, as the genes in plastids are highly conserved.
- The detail of the warning logged in `collect_MSAs()` has been reduced. I was unable to reproduce the conditions that caused this warning in the execution of CDS on the benchmark 2 dataset, so let us keep an eye on that in the future.
- To properly handle the exclusion of genes from evaluation in all three execution options (CDS, INT, IGS), these genes are removed during the feature filtering process of extraction (which already included things like checking the type of the feature). This should improve execution time, as we no longer extract features that we know won't be used, and we do not have to iterate over the regions to filter them out after the fact.
- MAFFT is now bundled in the repo and will be included in the package implementation in the future. The configuration to appropriately call MAFFT is encapsulated in a class and contains the transplanted `_align_mafft()` method as `align()`.<br>
The use of `Cogent3` as an alternative aligner was investigated, but was determined to not be a good fit for the existing software. It can not be understated how fast the default FFT-NS-2 MAFFT alignment is (and likely other command line aligners that use FFT). The tree-based alignment performed by `Cogent3` is substantially slower. When the alignment process is performed on an example machine configuration for a single region, MAFFT typically takes a few seconds for either nucleotide or protein alignment, a non-progressive nucleotide alignment with `Cogent3` using the HKY85 model has a runtime in excess of 30 seconds, and a non-progressive protein alignment with `Cogent3` using any of the applicable protein models (Jones-Taylor-Thornton, Whelan-Goldman, Dayhoff) requires over **ten minutes** to complete. The slower nucleotide alignment for `Cogent3` would probably be an acceptable tradeoff for using a Python-native solution, but the duration of protein alignment truly excludes this as a reasonable alternative.<br>
The current solution for the requirement of MAFFT is to include a portable version of MAFFT in the repo and use this if MAFFT is not installed on the system. Due to other assumptions in the existing code the portable version is compiled and configured for Linux, but MacOS and Windows support could be added if desired. As a package, we could instead download the portable version from MAFFT for the appropriate OS during package installation, and we can make a decision on that in the future.

Other changes

- The filtering of record features for the appropriate execution mode has been refactored into separate methods, which is where the exclusion list is now being used. In addition to the exclusion list as a filtering criterion, orfs are also filtered out here.
- Handling duplicate regions of the same plastome is now done during the `add_feature()` method of `PlastidDict`.
- The only cleaning operations done by `DataCleaning` are those that can only be performed after the extraction - that of removing regions based upon `min_seq_length` and `min_num_taxa`. These are performed during a single iteration over the regions.
- During CDS execution, `save_unaligned()` saves both nucleotide and protein matrices to file. Previously, the protein matrix was saved during `single_prot_MSA()`.
- A command line option to perform the writing of concatenated data to file sequentially has been added. The default option is to perform this operation synchronously, but there are certain scenarios where the sequential approach is more efficient. Sequentially writing the files is faster in memory-limited scenarios, but I have not found a heuristic to determine this beforehand.
- During `_backtrans_seq()` in `BackTranslation`, `ungap()` is a fallback method for older versions of `Biopython`.
- The command line argument `--excllist` now supports multiple specified genes.

Package implementation

- The package is called `plastidburstalign` to align with Python naming conventions. This is also reflected in the name now used in the README.
- In general, although existing in separate modules, the behavior of the "script" works the same as before. This is accomplished by including a `__main__.py` file which will be called when the package is executed as a script. If the current working directory contains the top level of the package (the directory `plastburstalign`) or the package is installed, the pipeline can be called with default arguments by
```
python -m plastburstalign
``` 
- The usage of specified arguments is the same—for example, `test_script_cds.py benchmarking1` calls
```
python -m plastburstalign -i benchmarking/benchmarking1 -o benchmarking/benchmarking1/output_cds -s cds -t 5 -l 6 -n 10
```
- In addition to using the package as a script, the components can be used within Python itself. Within  `test_script_cds.py benchmarking1` the pipeline could have been equivalently executed with
```
from plastburstalign import UserParameters, PlastomeRegionBurstAndAlign

params = UserParameters(
    in_dir="benchmarking/benchmarking1",
    out_dir="benchmarking/benchmarking1/output_cds",
    select_mode="cds",
    min_num_taxa=5,
    min_seq_length=6,
    num_threads=10
)
burst = PlastomeRegionBurstAndAlign(params)
burst.execute()
```
- A note about the instantiation of the `UserParameters` object as detailed above. Previously instances of the object were created from an `ArgumentParser`, as it was contained within a script. Now this constructor is more standard and receives individual arguments specified by the user. To emulate the previous behavior of the class there is `UserParametersScript`, which parses command line arguments and "forwards" them to this parameterized constructor. This is the class that is used within the aforementioned `__main__.py` and should be used in other script implementations that utilize components of the package.
- To facilitate the usage of the components separately, `UserParameters` acts just like a standard `dict` and can be treated as such (it is a child of `dict`). This means that instead of creating an instance of `UserParameters`, you can use a dictionary containing the necessary specifications for a more limited use case. The main purpose of `UserParameters` is to provide an easy way to validate specifications and to automatically set default values for unspecified arguments/parameters.
- More technical things can be said about how the logger is handled within the package, but in terms of usage the process identifier is now included for verbose logging. Among other things, this will help diagnose odd multiprocessing behavior that would be challenging to parse otherwise.
- Instead of including MAFFT within the package itself, the package will download the platform-appropriate portable MAFFT on an as-needed basis. As before, if MAFFT is installed on the system, that will be used. It will then check if the necessary portable MAFFT is located within the package, and if so, that will be used. Otherwise, an attempt to download the portable MAFFT will occur, and if successful, will then be used. If none of these steps are successful, any attempt to use the `MAFFT` object will result in a preemptive return and no alignment. Note that after MAFFT has been downloaded once, it will be immediately available to be used by any succeeding `MAFFT` objects as the files are now contained within the package directory.
- There has been an effort to add and standardize the documentation of features intended to be used by an end-user. Other documentation that was already present has been maintained, and less obvious "private" code has had some documentation added as well.
- Observe that the build configuration for the package is located in `pyproject.toml`. The existence of this file relates to the GitHub action that is present in this pull request. As the file, among other things, contains the metadata of the package, changes to it trigger an action to publish the package as a GitHub release and to publish the package on PyPI. Due to how Trusted Publisher Management works, it would be more accurate to say that this action _should_ publish the package on PyPI, as only `michaelgruenstaeudl/PlastomeBurstAndAlign` has permission to do this. I have tested a similar configuration with my fork and TestPyPI, which did work as expected.